### PR TITLE
Fixed truncation of trailing zeros in LIDVID

### DIFF
--- a/src/main/java/gov/nasa/pds/registry/common/util/json/RegistryDocBuilder.java
+++ b/src/main/java/gov/nasa/pds/registry/common/util/json/RegistryDocBuilder.java
@@ -22,7 +22,7 @@ public class RegistryDocBuilder
      */
     public static String createPKJson(Metadata meta) throws Exception
     {
-        String lidvid = meta.lid + "::" + meta.vid;
+        String lidvid = meta.lidvid;
         String pkJson = NJsonDocUtils.createPKJson(lidvid);
         return pkJson;
     }
@@ -36,8 +36,6 @@ public class RegistryDocBuilder
      */
     public static String createDataJson(Metadata meta, String jobId) throws Exception
     {
-        String lidvid = meta.lid + "::" + meta.vid;
-        
         StringWriter sw = new StringWriter();
         JsonWriter jw = new JsonWriter(sw);
         
@@ -46,7 +44,7 @@ public class RegistryDocBuilder
         // Basic info
         NJsonDocUtils.writeField(jw, "lid", meta.lid);
         NJsonDocUtils.writeField(jw, "vid", meta.strVid);
-        NJsonDocUtils.writeField(jw, "lidvid", lidvid);
+        NJsonDocUtils.writeField(jw, "lidvid", meta.lidvid);
         NJsonDocUtils.writeField(jw, "title", meta.title);
         NJsonDocUtils.writeField(jw, "product_class", meta.prodClass);
 


### PR DESCRIPTION
## 🗒️ Summary
Fixed `_id` and `lidvid` field generator to not truncate trailing zeros of a version id.

## ⚙️ Test Data and/or Report
See Harvest pull request https://github.com/NASA-PDS/harvest/pull/91

## ♻️ Related Issues
https://github.com/NASA-PDS/harvest/issues/90
