### PR TITLE
Retry resilience stopgap v2

### DIFF
--- a/src/main/java/gov/nasa/pds/registry/common/es/dao/DataLoader.java
+++ b/src/main/java/gov/nasa/pds/registry/common/es/dao/DataLoader.java
@@ -231,6 +231,12 @@ public class DataLoader
         }
         catch(IOException ex)
         {
+            if (retries > 0) {
+                String msg = ex.getMessage();
+                log.warn("DataLoader.loadBatch() request failed due to \"" + msg + "\" ("+ retries +" retries remaining)");
+                return loadBatch(fileReader, firstLine, retries - 1);
+            }
+
             // Get HTTP response code
             int respCode = getResponseCode(con);
             if(respCode <= 0) throw ex;
@@ -242,11 +248,6 @@ public class DataLoader
             // Parse error JSON to extract reason.
             String msg = EsUtils.extractReasonFromJson(json);
             if(msg == null) msg = json;
-
-            if (retries > 0) {
-                log.warn("DataLoader.loadBatch() request failed due to \"" + msg + "\" ("+ retries +" retries remaining)");
-                return loadBatch(fileReader, firstLine, retries - 1);
-            }
 
             throw new Exception(msg);
         }
@@ -323,6 +324,12 @@ public class DataLoader
         }
         catch(IOException ex)
         {
+            if (retries > 0) {
+                String msg = ex.getMessage();
+                log.warn("DataLoader.loadBatch() request failed due to \"" + msg + "\" ("+ retries +" retries remaining)");
+                return loadBatch(data, errorLidvids, retries - 1);
+            }
+
             // Get HTTP response code
             int respCode = getResponseCode(con);
             if(respCode <= 0) throw ex;
@@ -334,11 +341,6 @@ public class DataLoader
             // Parse error JSON to extract reason.
             String msg = EsUtils.extractReasonFromJson(json);
             if(msg == null) msg = json;
-
-            if (retries > 0) {
-                log.warn("DataLoader.loadBatch() request failed due to \"" + msg + "\" ("+ retries +" retries remaining)");
-                return loadBatch(data, errorLidvids, retries - 1);
-              }
 
             throw new Exception(msg);
         }

--- a/src/main/java/gov/nasa/pds/registry/common/es/dao/DataLoader.java
+++ b/src/main/java/gov/nasa/pds/registry/common/es/dao/DataLoader.java
@@ -35,6 +35,7 @@ import gov.nasa.pds.registry.common.util.CloseUtils;
  */
 public class DataLoader
 {
+    private int defaultRequestRetries = 5;
     private int printProgressSize = 500;
     private int batchSize = 100;
     private int totalRecords;
@@ -147,8 +148,7 @@ public class DataLoader
 
 
     private String loadBatch(BufferedReader fileReader, String firstLine) throws Exception {
-        int defaultRetries = 5;
-        return loadBatch(fileReader, firstLine, defaultRetries);
+        return loadBatch(fileReader, firstLine, defaultRequestRetries);
     }
 
     /**
@@ -266,8 +266,7 @@ public class DataLoader
      */
     public int loadBatch(List<String> data, Set<String> errorLidvids) throws Exception
     {
-        int defaultRetries = 5;
-        return loadBatch(data, errorLidvids, defaultRetries);
+        return loadBatch(data, errorLidvids, defaultRequestRetries);
     }
 
     /**

--- a/src/main/java/gov/nasa/pds/registry/common/es/dao/DataLoader.java
+++ b/src/main/java/gov/nasa/pds/registry/common/es/dao/DataLoader.java
@@ -492,7 +492,7 @@ public class DataLoader
      * @param is input stream
      * @return Last line
      */
-    private static String getLastLine(InputStream is)
+    private String getLastLine(InputStream is)
     {
         String lastLine = null;
 
@@ -508,7 +508,7 @@ public class DataLoader
         }
         catch(Exception ex)
         {
-            // Ignore
+            log.info("Exception thrown in DataLoader.getLastLine() - please inform developer", ex);
         }
         finally
         {


### PR DESCRIPTION
## 🗒️ Summary
- extends retry behaviour to previously-missed implementation of `DataLoader.loadBatch()`
- replaces a silent exception catch with a (to-be-updated) INFO-level log message
- ensures that retries will occur for *any* instance of IOException, not just those that make it past the status code checks and response parsing.

## ⚙️ Test Data and/or Report
Manually tested, but code should be inspected closely in peer review

## ♻️ Related Issues
extends #42 
addresses https://github.com/NASA-PDS/harvest/issues/125

