### PR TITLE
Update connections to support new AWS connection scheme

### DIFF
--- a/src/main/java/gov/nasa/pds/registry/common/connection/aws/GetRespWrap.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/aws/GetRespWrap.java
@@ -2,6 +2,7 @@ package gov.nasa.pds.registry.common.connection.aws;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.logging.log4j.LogManager;
@@ -33,7 +34,10 @@ class GetRespWrap implements Response.Get {
   @Override
   public String productClass() {
     String result = "";
-    if (true) throw new NotImplementedException("Need to fill this out when have a return value");
+    if (this.parent.source() != null) {
+      HashMap<String,String> src = (HashMap<String,String>)this.parent.source();
+      if (src.containsValue("product_class")) result = src.get("product_class");
+    }
     return result;
   }
   @Override

--- a/src/main/resources/connections/cognito/development.xml
+++ b/src/main/resources/connections/cognito/development.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <registry_connection index="als_test_registry_5">
   <cognitoClientId endpoint="https://p5qmxrldysl1gy759hqf.us-west-2.aoss.amazonaws.com"
-                   gateway="https://c8u1zk30u5.execute-api.us-west-2.amazonaws.com/dev/signed-url"
+                   gateway="https://c8u1zk30u5.execute-api.us-west-2.amazonaws.com/dev/credentials"
                    IDP="https://cognito-idp.us-west-2.amazonaws.com"
                    >47d9j6ks9un4errq6pnbu0bc1r</cognitoClientId>
 </registry_connection>


### PR DESCRIPTION
## 🗒️ Summary
Update registry to match new protocol

## ⚙️ Test Data and/or Report
Ran harvest"
```
[SUMMARY] Reading configuration from /home/niessner/Projects/PDS/registry-ref-data/directories_test.cog.xml
[SUMMARY] Output directory: /tmp/harvest/out
[SUMMARY] Connection: gov.nasa.pds.registry.common.connection.UseOpensearchSDK2@6e46d9f4
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[INFO] Connecting to Elasticsearch
```

## ♻️ Related Issues
Closes #50 

