### PR TITLE
validate 895: upgrade RI to SDK V2 through common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,13 +67,6 @@ POSSIBILITY OF SUCH DAMAGE.
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
-    <repositories>
-      <repository>
-        <id>Openseach Snapshots</id>
-        <url>https://aws.oss.sonatype.org/content/repositories/snapshots</url>
-      </repository>
-    </repositories>
- 
     <dependencies>
         <!-- TEST ONLY: JUnit -->
         <dependency>
@@ -148,7 +141,7 @@ POSSIBILITY OF SUCH DAMAGE.
         <dependency>
           <groupId>org.opensearch.client</groupId>
           <artifactId>opensearch-java</artifactId>
-          <version>3.0.0-SNAPSHOT</version>
+          <version>2.13.0</version>
         </dependency>
         <dependency>
           <groupId>software.amazon.awssdk</groupId>

--- a/src/main/java/gov/nasa/pds/registry/common/Request.java
+++ b/src/main/java/gov/nasa/pds/registry/common/Request.java
@@ -45,6 +45,7 @@ public interface Request {
     public Search all(String sortField, int size, String searchAfter);
     public Search all(String filterField, String filterValue, String sortField, int size, String searchAfter);
     public Search buildAlternativeIds(Collection<String> lids);
+    public Search buildFindDuplicates(int page_size);
     public Search buildGetField(String field_name, String lidvid);
     public Search buildLatestLidVids(Collection<String> lids);
     public Search buildListFields(String dataType);
@@ -54,6 +55,7 @@ public interface Request {
     public Search setIndex (String name);
     public Search setPretty (boolean pretty);
     public Search setSize (int hitsperpage);
+    public Search setReturnedFields(Collection<String> names);
   }
   public interface Setting { // _settings
     public Setting setIndex (String name);

--- a/src/main/java/gov/nasa/pds/registry/common/Response.java
+++ b/src/main/java/gov/nasa/pds/registry/common/Response.java
@@ -47,6 +47,7 @@ public interface Response {
   public interface Search {
     public Map<String,Set<String>> altIds() throws UnsupportedOperationException, IOException;
     public List<Object> batch() throws UnsupportedOperationException, IOException;
+    public List<String> bucketValues();
     public List<Map<String,Object>> documents();
     public String field(String name) throws NoSuchFieldException; // null means blob not in document and NoSuchFieldException document not found
     public Set<String> fields() throws UnsupportedOperationException, IOException;

--- a/src/main/java/gov/nasa/pds/registry/common/connection/UseOpensearchSDK2.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/UseOpensearchSDK2.java
@@ -29,6 +29,7 @@ public final class UseOpensearchSDK2 implements ConnectionFactory {
   final private URL endpoint;
   private String index = null;
   public static UseOpensearchSDK2 build (CognitoType cog, AuthContent auth) throws IOException, InterruptedException {
+    System.setProperty("org.opensearch.path.encoding","HTTP_CLIENT_V5_EQUIV"); // opensearch-java >= 2.13 not needed >= 3.x
     boolean expectedContent = true;
     Gson gson = new Gson();
     HttpClient client = HttpClient.newHttpClient();

--- a/src/main/java/gov/nasa/pds/registry/common/connection/aws/SearchImpl.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/aws/SearchImpl.java
@@ -98,8 +98,12 @@ class SearchImpl implements Search {
   }
   @Override
   public Search all(String sortField, int size, String searchAfter) {
+    /** opensearch 3.x
     FieldValue fv = new FieldValue.Builder().stringValue(searchAfter).build();
     this.craftsman.searchAfter(Arrays.asList(fv));
+    */
+    /** opensearch 2.x */
+    this.craftsman.searchAfter(Arrays.asList(searchAfter));
     this.craftsman.sort(new SortOptions.Builder()
         .field(new FieldSort.Builder().field(sortField).order(SortOrder.Asc).build())
         .build());

--- a/src/main/java/gov/nasa/pds/registry/common/connection/aws/SearchImpl.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/aws/SearchImpl.java
@@ -10,7 +10,6 @@ import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
 import org.opensearch.client.opensearch._types.aggregations.TermsAggregation;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
-import org.opensearch.client.opensearch._types.query_dsl.FieldAndFormat;
 import org.opensearch.client.opensearch._types.query_dsl.IdsQuery;
 import org.opensearch.client.opensearch._types.query_dsl.MatchQuery;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
@@ -141,9 +140,9 @@ class SearchImpl implements Search {
   }
   @Override
   public Search setReturnedFields(Collection<String> names) {
-    for (String name : names) {
-      this.craftsman.fields(new FieldAndFormat.Builder().field(name).build());
-    }
+    this.craftsman.source(new SourceConfig.Builder()
+        .filter(new SourceFilter.Builder()
+            .includes(new ArrayList<String>(names)).build()).build());
     return this;
   }
 }

--- a/src/main/java/gov/nasa/pds/registry/common/connection/aws/SearchImpl.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/aws/SearchImpl.java
@@ -7,7 +7,10 @@ import org.opensearch.client.opensearch._types.FieldSort;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.SortOptions;
 import org.opensearch.client.opensearch._types.SortOrder;
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch._types.aggregations.TermsAggregation;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
+import org.opensearch.client.opensearch._types.query_dsl.FieldAndFormat;
 import org.opensearch.client.opensearch._types.query_dsl.IdsQuery;
 import org.opensearch.client.opensearch._types.query_dsl.MatchQuery;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
@@ -33,6 +36,14 @@ class SearchImpl implements Search {
   }
   private Query.Builder matchQuery (String fieldname, String fieldvalue) {
     return (Builder)new Query.Builder().match(new MatchQuery.Builder().field(fieldname).query(new FieldValue.Builder().stringValue(fieldvalue).build()).build());
+  }
+  @Override
+  public Search buildFindDuplicates(int page_size) {
+    this.craftsman.aggregations("duplicates",
+        new Aggregation.Builder().terms(
+            new TermsAggregation.Builder().field("ops:Data_File_Info/ops:file_ref").minDocCount(2).size(page_size).build())
+        .build());
+    return this;
   }
   @Override
   public Search buildAlternativeIds(Collection<String> lids) {
@@ -122,6 +133,13 @@ class SearchImpl implements Search {
   @Override
   public Search setSize(int hitsperpage) {
     this.craftsman.size(hitsperpage);
+    return this;
+  }
+  @Override
+  public Search setReturnedFields(Collection<String> names) {
+    for (String name : names) {
+      this.craftsman.fields(new FieldAndFormat.Builder().field(name).build());
+    }
     return this;
   }
 }

--- a/src/main/java/gov/nasa/pds/registry/common/connection/aws/SearchRespWrap.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/aws/SearchRespWrap.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.NotImplementedException;
+import org.opensearch.client.opensearch._types.aggregations.StringTermsBucket;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.core.search.Hit;
 import gov.nasa.pds.registry.common.Response;
@@ -87,5 +88,13 @@ class SearchRespWrap implements Response.Search {
       docs.add((Map<String,Object>)doc);
     }
     return docs;
+  }
+  @Override
+  public List<String> bucketValues() {
+    ArrayList<String> keys =  new ArrayList<String>();
+    for (StringTermsBucket bucket : this.parent.aggregations().get("duplicates").sterms().buckets().array()) {
+      keys.add(bucket.key());
+    }
+    return keys;
   }
 }

--- a/src/main/java/gov/nasa/pds/registry/common/connection/aws/SearchRespWrap.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/aws/SearchRespWrap.java
@@ -87,6 +87,11 @@ class SearchRespWrap implements Response.Search {
     for (Object doc : this.parent.documents()) {
       docs.add((Map<String,Object>)doc);
     }
+    if (docs.isEmpty()) { // try hits
+      for (Hit<Object> hit : this.parent.hits().hits()) {
+        docs.add((Map<String,Object>)hit.source());
+      }
+    }
     return docs;
   }
   @Override

--- a/src/main/java/gov/nasa/pds/registry/common/connection/es/SearchImpl.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/es/SearchImpl.java
@@ -70,4 +70,12 @@ class SearchImpl implements Search {
   public Search setSize(int hitsperpage) {
     throw new NotImplementedException();
   }
+  @Override
+  public Search buildFindDuplicates(int page_size) {
+    throw new NotImplementedException();
+  }
+  @Override
+  public Search setReturnedFields(Collection<String> names) {
+    throw new NotImplementedException();
+  }
 }

--- a/src/main/java/gov/nasa/pds/registry/common/connection/es/SearchRespImpl.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/es/SearchRespImpl.java
@@ -179,4 +179,8 @@ class SearchRespImpl implements Response.Search {
   public List<Map<String, Object>> documents() {
     throw new NotImplementedException();
   }
+  @Override
+  public List<String> bucketValues() {
+    throw new NotImplementedException();
+  }
 }


### PR DESCRIPTION
## 🗒️ Summary
Needed some upgrades to registry-common to handle requests being made for Reference Integrity (RI). Also moved back to opensearch 2.13.0 with java property.

## ⚙️ Test Data and/or Report
Loaded a test DB then ran RI in validate.

## ♻️ Related Issues
Related to NASA-PDS/validate#895