### PR TITLE
Implement reconnect after timeout functionality and scrolling functionality

### DIFF
--- a/src/main/java/gov/nasa/pds/registry/common/ConnectionFactory.java
+++ b/src/main/java/gov/nasa/pds/registry/common/ConnectionFactory.java
@@ -1,5 +1,6 @@
 package gov.nasa.pds.registry.common;
 
+import java.io.IOException;
 import org.apache.http.HttpHost;
 import org.apache.http.client.CredentialsProvider;
 
@@ -13,5 +14,6 @@ public interface ConnectionFactory {
   public String getHostName();
   public String getIndexName();
   public boolean isTrustingSelfSigned();
+  public void reconnect() throws IOException, InterruptedException; // used when credentials time out otherwise not defined
   public ConnectionFactory setIndexName (String idxName);
 }

--- a/src/main/java/gov/nasa/pds/registry/common/Request.java
+++ b/src/main/java/gov/nasa/pds/registry/common/Request.java
@@ -52,10 +52,10 @@ public interface Request {
     public Search buildListFields(String dataType);
     public Search buildListLdds (String namespace);
     public Search buildTermQuery (String fieldname, String value);
+    public Search buildTermQueryWithoutTermQuery (String yesFieldname, String yesValue, String noFieldname, String noValue);
     public Search buildTheseIds(Collection<String> lids);
     public Search setIndex (String name);
     public Search setPretty (boolean pretty);
-    public Search setScroll (int hitsperpage);
     public Search setReturnedFields(Collection<String> names);
   }
   public interface Setting { // _settings

--- a/src/main/java/gov/nasa/pds/registry/common/Request.java
+++ b/src/main/java/gov/nasa/pds/registry/common/Request.java
@@ -55,7 +55,7 @@ public interface Request {
     public Search buildTheseIds(Collection<String> lids);
     public Search setIndex (String name);
     public Search setPretty (boolean pretty);
-    public Search setSize (int hitsperpage);
+    public Search setScroll (int hitsperpage);
     public Search setReturnedFields(Collection<String> names);
   }
   public interface Setting { // _settings

--- a/src/main/java/gov/nasa/pds/registry/common/connection/CognitoContent.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/CognitoContent.java
@@ -1,0 +1,11 @@
+package gov.nasa.pds.registry.common.connection;
+
+class CognitoContent {
+  String accessToken;
+  String clientid;
+  String gateway;
+  String idp;
+  String idToken;
+  String refreshToken;
+  String tokenType;
+}

--- a/src/main/java/gov/nasa/pds/registry/common/connection/UseOpensearchSDK1.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/UseOpensearchSDK1.java
@@ -3,6 +3,7 @@ package gov.nasa.pds.registry.common.connection;
 import java.net.URL;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.http.HttpHost;
 import org.apache.http.client.CredentialsProvider;
 import gov.nasa.pds.registry.common.ConnectionFactory;
@@ -83,5 +84,10 @@ public class UseOpensearchSDK1 implements ConnectionFactory {
   @Override
   public boolean isTrustingSelfSigned() {
     return this.veryTrusting;
+  }
+
+  @Override
+  public void reconnect() {
+    throw new NotImplementedException();
   }
 }

--- a/src/main/java/gov/nasa/pds/registry/common/connection/UseOpensearchSDK2.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/UseOpensearchSDK2.java
@@ -181,13 +181,12 @@ public final class UseOpensearchSDK2 implements ConnectionFactory {
     if (this.isServerless) {
       boolean expectedContent = true;
       Gson gson = new Gson();
-      String cid = "47d9j6ks9un4errq6pnbu0bc1r";
       HttpClient client = HttpClient.newHttpClient();
       HttpRequest request = HttpRequest.newBuilder()
           .uri(URI.create(this.content.idp))
           .POST(BodyPublishers.ofString("{\"AuthFlow\":\"REFRESH_TOKEN_AUTH\",\"AuthParameters\":{"
               + "\"REFRESH_TOKEN\":\"" + this.content.refreshToken + "\""
-              + "},\"ClientId\":\"" + cid + "\""
+              + "},\"ClientId\":\"" + this.content.clientid + "\""
               + "}"))
           .setHeader("X-Amz-Target", "AWSCognitoIdentityProviderService.InitiateAuth")
           .setHeader("Content-Type", "application/x-amz-json-1.1")

--- a/src/main/java/gov/nasa/pds/registry/common/connection/UseOpensearchSDK2.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/UseOpensearchSDK2.java
@@ -24,6 +24,7 @@ public final class UseOpensearchSDK2 implements ConnectionFactory {
   final private boolean isServerless;
   final private boolean veryTrusting;
   final private AuthContent auth;
+  final private CognitoContent content;
   final private HttpHost host;
   final private org.apache.hc.core5.http.HttpHost host5;
   final private URL endpoint;
@@ -45,7 +46,6 @@ public final class UseOpensearchSDK2 implements ConnectionFactory {
         .build();
     HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
     Map<String,Map<String,String>> content;
-    Properties awsCreds = new Properties(System.getProperties()); // initialize properties as oracle suggests
     Type contentType = new TypeToken<Map<String,Map<String,String>>>(){}.getType();
 
     expectedContent &= response.body().contains("AuthenticationResult");
@@ -60,16 +60,48 @@ public final class UseOpensearchSDK2 implements ConnectionFactory {
       + " ->\n" + response.body());
     }
     content = gson.fromJson(response.body(), contentType);
-    client = HttpClient.newBuilder()
+    return new UseOpensearchSDK2(auth, new URL(cog.getEndpoint()), true, false)
+        .update(content, cog.getValue(), cog.getIDP(), cog.getGateway())
+        .tokensToKeys();
+  }
+  private UseOpensearchSDK2 update (Map<String,Map<String,String>> content, String cid, String idp, String gateway) {
+    this.content.accessToken = content.get("AuthenticationResult").get("AccessToken");
+    this.content.clientid = cid;
+    this.content.gateway = gateway;
+    this.content.idp = idp;
+    this.content.idToken = content.get("AuthenticationResult").get("IdToken");
+    this.content.refreshToken = content.get("AuthenticationResult").get("RefreshToken");
+    this.content.tokenType = content.get("AuthenticationResult").get("TokenType");
+    return this;
+  }
+  private UseOpensearchSDK2 update (CognitoContent old) {
+    if (this.isServerless) {
+      this.content.accessToken = old.accessToken;
+      this.content.clientid = old.clientid;
+      this.content.gateway = old.gateway;
+      this.content.idp  = old.idp;
+      this.content.idToken = old.idToken;
+      this.content.refreshToken = old.refreshToken;
+      this.content.tokenType = old.tokenType;
+    }
+    return this;
+  }
+  private UseOpensearchSDK2 tokensToKeys() throws IOException, InterruptedException {
+    boolean expectedContent = true;
+    Gson gson = new Gson();
+    HttpClient client = HttpClient.newBuilder()
         .followRedirects(HttpClient.Redirect.NORMAL)
         .build();
-    request = HttpRequest.newBuilder()
-        .uri(URI.create(cog.getGateway()))
+    HttpRequest request = HttpRequest.newBuilder()
+        .uri(URI.create(this.content.gateway))
         .GET()
-        .setHeader("Authorization", content.get("AuthenticationResult").get("TokenType") + " " + content.get("AuthenticationResult").get("AccessToken"))
-        .setHeader("IDToken", content.get("AuthenticationResult").get("IdToken"))
+        .setHeader("Authorization", this.content.tokenType + " " + this.content.accessToken)
+        .setHeader("IDToken", this.content.idToken)
         .build();
-    response = client.send(request, HttpResponse.BodyHandlers.ofString());
+    HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+    Map<String,Map<String,String>> content;
+    Properties awsCreds = new Properties(System.getProperties()); // initialize properties as oracle suggests
+    Type contentType = new TypeToken<Map<String,Map<String,String>>>(){}.getType();
     if (299 < response.statusCode()) {
       throw new IOException("Could not obtain credentials: " + response.toString());
     }
@@ -87,13 +119,14 @@ public final class UseOpensearchSDK2 implements ConnectionFactory {
     awsCreds.setProperty("aws.secretAccessKey", content.get("Credentials").get("SecretAccessKey"));
     awsCreds.setProperty("aws.sessionToken", content.get("Credentials").get("SessionToken"));
     System.setProperties(awsCreds);
-    return new UseOpensearchSDK2(auth, new URL(cog.getEndpoint()), true, false);
+    return this;
   }
   public static UseOpensearchSDK2 build (DirectType url, AuthContent auth) throws Exception {
     return new UseOpensearchSDK2(auth, new URL(url.getValue()), false, url.isTrustSelfSigned());
   }
   private UseOpensearchSDK2 (AuthContent auth, URL opensearchEndpoint, boolean isServerless, boolean veryTrusting) {
     this.auth = auth;
+    this.content = new CognitoContent();
     this.endpoint = opensearchEndpoint;
     this.host = new HttpHost(this.endpoint.getHost(), this.endpoint.getPort(), this.endpoint.getProtocol());
     this.host5 = new org.apache.hc.core5.http.HttpHost(this.endpoint.getProtocol(), this.endpoint.getHost(), this.endpoint.getPort());
@@ -102,7 +135,9 @@ public final class UseOpensearchSDK2 implements ConnectionFactory {
   }
   @Override
   public ConnectionFactory clone() {
-    return new UseOpensearchSDK2(this.auth, this.endpoint, this.isServerless, this.veryTrusting).setIndexName(this.index);
+    return new UseOpensearchSDK2(this.auth, this.endpoint, this.isServerless, this.veryTrusting)
+        .update(this.content)
+        .setIndexName(this.index);
   }
   @Override
   public RestClient createRestClient() throws Exception {
@@ -140,5 +175,41 @@ public final class UseOpensearchSDK2 implements ConnectionFactory {
   public ConnectionFactory setIndexName(String idxName) {
     this.index = idxName;
     return this;
+  }
+  @Override
+  public void reconnect() throws IOException, InterruptedException {
+    if (this.isServerless) {
+      boolean expectedContent = true;
+      Gson gson = new Gson();
+      String cid = "47d9j6ks9un4errq6pnbu0bc1r";
+      HttpClient client = HttpClient.newHttpClient();
+      HttpRequest request = HttpRequest.newBuilder()
+          .uri(URI.create(this.content.idp))
+          .POST(BodyPublishers.ofString("{\"AuthFlow\":\"REFRESH_TOKEN_AUTH\",\"AuthParameters\":{"
+              + "\"REFRESH_TOKEN\":\"" + this.content.refreshToken + "\""
+              + "},\"ClientId\":\"" + cid + "\""
+              + "}"))
+          .setHeader("X-Amz-Target", "AWSCognitoIdentityProviderService.InitiateAuth")
+          .setHeader("Content-Type", "application/x-amz-json-1.1")
+          .build();
+      HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+      Map<String,Map<String,String>> content;
+      Type contentType = new TypeToken<Map<String,Map<String,String>>>(){}.getType();
+
+      expectedContent &= response.body().contains("AuthenticationResult");
+      expectedContent &= response.body().contains("AccessToken");
+      expectedContent &= response.body().contains("ExpiresIn");
+      expectedContent &= response.body().contains("IdToken");
+      expectedContent &= response.body().contains("TokenType");
+      expectedContent &= response.body().contains("ChallengeParameters");
+      if (!expectedContent) {
+        throw new IOException("Received an unexpected response of: " + response.toString()
+        + " ->\n" + response.body());
+      }
+      content = gson.fromJson(response.body(), contentType);
+      content.get("AuthenticationResult").put("RefreshToken", this.content.refreshToken);
+      this.update(content, this.content.clientid, this.content.idp, this.content.gateway);
+      this.tokensToKeys();
+    }
   }
 }

--- a/src/main/java/gov/nasa/pds/registry/common/connection/aws/DBQImpl.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/aws/DBQImpl.java
@@ -1,13 +1,14 @@
 package gov.nasa.pds.registry.common.connection.aws;
 
 import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.Time;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch._types.query_dsl.TermQuery;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import gov.nasa.pds.registry.common.Request;
 
 class DBQImpl implements Request.DeleteByQuery {
-  final SearchRequest.Builder craftsman = new SearchRequest.Builder();
+  final SearchRequest.Builder craftsman = new SearchRequest.Builder().scroll(new Time.Builder().time("24m").build());
   String index;
   @Override
   public Request.DeleteByQuery createFilterQuery(String key, String value) {

--- a/src/main/java/gov/nasa/pds/registry/common/connection/aws/DBQImpl.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/aws/DBQImpl.java
@@ -1,15 +1,21 @@
 package gov.nasa.pds.registry.common.connection.aws;
 
+import java.util.ArrayList;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.Time;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch._types.query_dsl.TermQuery;
 import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.search.SourceConfig;
+import org.opensearch.client.opensearch.core.search.SourceFilter;
 import gov.nasa.pds.registry.common.Request;
 
 class DBQImpl implements Request.DeleteByQuery {
-  final SearchRequest.Builder craftsman = new SearchRequest.Builder().scroll(new Time.Builder().time("24m").build());
-  String index;
+  final SearchRequest.Builder craftsman = new SearchRequest.Builder()
+      .source(new SourceConfig.Builder().filter(new SourceFilter.Builder().includes("lidvid").build()).build())
+      .scroll(new Time.Builder().time("24m").build())
+      .size(2000);
+  final ArrayList<String> index = new ArrayList<String>();
   @Override
   public Request.DeleteByQuery createFilterQuery(String key, String value) {
     this.craftsman.query(new Query.Builder().term(new TermQuery.Builder()
@@ -26,7 +32,7 @@ class DBQImpl implements Request.DeleteByQuery {
   @Override
   public Request.DeleteByQuery setIndex(String name) {
     this.craftsman.index(name);
-    this.index = name;
+    this.index.add(name);
     return this;
   }
   @Override

--- a/src/main/java/gov/nasa/pds/registry/common/connection/aws/DBQImpl.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/aws/DBQImpl.java
@@ -2,7 +2,6 @@ package gov.nasa.pds.registry.common.connection.aws;
 
 import java.util.ArrayList;
 import org.opensearch.client.opensearch._types.FieldValue;
-import org.opensearch.client.opensearch._types.Time;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch._types.query_dsl.TermQuery;
 import org.opensearch.client.opensearch.core.SearchRequest;
@@ -12,9 +11,7 @@ import gov.nasa.pds.registry.common.Request;
 
 class DBQImpl implements Request.DeleteByQuery {
   final SearchRequest.Builder craftsman = new SearchRequest.Builder()
-      .source(new SourceConfig.Builder().filter(new SourceFilter.Builder().includes("lidvid").build()).build())
-      .scroll(new Time.Builder().time("24m").build())
-      .size(2000);
+      .source(new SourceConfig.Builder().filter(new SourceFilter.Builder().includes("lidvid").build()).build());
   final ArrayList<String> index = new ArrayList<String>();
   @Override
   public Request.DeleteByQuery createFilterQuery(String key, String value) {

--- a/src/main/java/gov/nasa/pds/registry/common/connection/aws/RestClientWrapper.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/aws/RestClientWrapper.java
@@ -228,7 +228,7 @@ public class RestClientWrapper implements RestClient {
       @Override
       public Long perform (SearchRequest arg) throws IOException, ResponseException {
       return _performDBQRequest(arg);
-    }}.retry(((DBQImpl)request).craftsman.size(2).build());
+    }}.retry(((DBQImpl)request).craftsman.build());
   }
   private long _performDBQRequest(SearchRequest request) throws IOException, ResponseException {
     SearchResponse<Object> items = this.client.search(request, Object.class);

--- a/src/main/java/gov/nasa/pds/registry/common/connection/aws/RestClientWrapper.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/aws/RestClientWrapper.java
@@ -155,7 +155,8 @@ public class RestClientWrapper implements RestClient {
   }
   @Override
   public Response.Search performRequest(Search request) throws IOException, ResponseException {
-    return new SearchRespWrap(this.client.search(((SearchImpl)request).craftsman.build(), Object.class));
+    return new SearchRespWrap(this.client,
+        this.client.search(((SearchImpl)request).craftsman.build(), Object.class));
   }
   @Override
   public Response.Settings performRequest(Setting request) throws IOException, ResponseException {

--- a/src/main/java/gov/nasa/pds/registry/common/connection/aws/SearchImpl.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/aws/SearchImpl.java
@@ -7,6 +7,7 @@ import org.opensearch.client.opensearch._types.FieldSort;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.SortOptions;
 import org.opensearch.client.opensearch._types.SortOrder;
+import org.opensearch.client.opensearch._types.Time;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
 import org.opensearch.client.opensearch._types.aggregations.TermsAggregation;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
@@ -144,8 +145,9 @@ class SearchImpl implements Search {
     return this;
   }
   @Override
-  public Search setSize(int hitsperpage) {
+  public Search setScroll(int hitsperpage) {
     this.craftsman.size(hitsperpage);
+    this.craftsman.scroll(new Time.Builder().time("24m").build());
     return this;
   }
   @Override

--- a/src/main/java/gov/nasa/pds/registry/common/connection/aws/SearchImpl.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/aws/SearchImpl.java
@@ -7,7 +7,6 @@ import org.opensearch.client.opensearch._types.FieldSort;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.SortOptions;
 import org.opensearch.client.opensearch._types.SortOrder;
-import org.opensearch.client.opensearch._types.Time;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
 import org.opensearch.client.opensearch._types.aggregations.TermsAggregation;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
@@ -145,9 +144,15 @@ class SearchImpl implements Search {
     return this;
   }
   @Override
-  public Search setScroll(int hitsperpage) {
-    this.craftsman.size(hitsperpage);
-    this.craftsman.scroll(new Time.Builder().time("24m").build());
+  public Search buildTermQueryWithoutTermQuery (String yesFieldname, String yesValue, String noFieldname, String noValue) {
+    BoolQuery.Builder journeyman = new BoolQuery.Builder()
+        .must(new Query.Builder().term(new TermQuery.Builder()
+            .field(yesFieldname)
+            .value(new FieldValue.Builder().stringValue(yesValue).build()).build()).build())
+        .mustNot(new Query.Builder().term(new TermQuery.Builder()
+            .field(noFieldname)
+            .value(new FieldValue.Builder().stringValue(noValue).build()).build()).build());
+    this.craftsman.query(new Query.Builder().bool(journeyman.build()).build());   
     return this;
   }
   @Override

--- a/src/main/java/gov/nasa/pds/registry/common/connection/aws/SearchRespWrap.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/aws/SearchRespWrap.java
@@ -12,7 +12,6 @@ import org.apache.commons.lang3.NotImplementedException;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.Time;
 import org.opensearch.client.opensearch._types.aggregations.StringTermsBucket;
-import org.opensearch.client.opensearch.core.ClearScrollRequest;
 import org.opensearch.client.opensearch.core.ScrollRequest;
 import org.opensearch.client.opensearch.core.ScrollResponse;
 import org.opensearch.client.opensearch.core.SearchResponse;
@@ -63,7 +62,6 @@ class SearchRespWrap implements Response.Search {
             lidvids.add(((Map<String,String>)hit.source()).get("lidvid"));
           }
         }
-        this.client.clearScroll(new ClearScrollRequest.Builder().scrollId(scrollID).build());
       } catch (IOException ioe) {
         throw new RuntimeException("How did we get here???", ioe);
       }

--- a/src/main/java/gov/nasa/pds/registry/common/connection/aws/SearchRespWrap.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/aws/SearchRespWrap.java
@@ -9,7 +9,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.NotImplementedException;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.Time;
 import org.opensearch.client.opensearch._types.aggregations.StringTermsBucket;
+import org.opensearch.client.opensearch.core.ClearScrollRequest;
+import org.opensearch.client.opensearch.core.ScrollRequest;
+import org.opensearch.client.opensearch.core.ScrollResponse;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.core.search.Hit;
 import gov.nasa.pds.registry.common.Response;
@@ -18,8 +23,10 @@ import gov.nasa.pds.registry.common.es.dao.dd.LddVersions;
 
 @SuppressWarnings("unchecked") // JSON heterogenous structures requires raw casting
 class SearchRespWrap implements Response.Search {
+  final private OpenSearchClient client;
   final private SearchResponse<Object> parent;
-  SearchRespWrap(SearchResponse<Object> parent) {
+  SearchRespWrap(OpenSearchClient client, SearchResponse<Object> parent) {
+    this.client = client;
     this.parent = parent;
   }
   @Override
@@ -41,8 +48,25 @@ class SearchRespWrap implements Response.Search {
   @Override
   public List<String> lidvids() {
     ArrayList<String> lidvids = new ArrayList<String>();
+    String scrollID = this.parent.scrollId();
     for (Hit<Object> hit : this.parent.hits().hits()) {
       lidvids.add(((Map<String,String>)hit.source()).get("lidvid"));
+    }
+    if (this.parent.scrollId() != null) {
+      try {
+        ScrollResponse<Object> page;
+        while (lidvids.size() < this.parent.hits().total().value()) {
+          page = this.client.scroll(new ScrollRequest.Builder()
+              .scroll(new Time.Builder().time("24m").build()).scrollId(scrollID).build(), Object.class);
+          scrollID = page.scrollId(); // docs say this can change
+          for (Hit<Object> hit : page.hits().hits()) {
+            lidvids.add(((Map<String,String>)hit.source()).get("lidvid"));
+          }
+        }
+        this.client.clearScroll(new ClearScrollRequest.Builder().scrollId(scrollID).build());
+      } catch (IOException ioe) {
+        throw new RuntimeException("How did we get here???", ioe);
+      }
     }
     return lidvids;
   }

--- a/src/main/java/gov/nasa/pds/registry/common/connection/es/SearchImpl.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/es/SearchImpl.java
@@ -71,7 +71,7 @@ class SearchImpl implements Search {
     throw new NotImplementedException();
   }
   @Override
-  public Search setSize(int hitsperpage) {
+  public Search setScroll(int hitsperpage) {
     throw new NotImplementedException();
   }
   @Override

--- a/src/main/java/gov/nasa/pds/registry/common/connection/es/SearchImpl.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/es/SearchImpl.java
@@ -71,7 +71,7 @@ class SearchImpl implements Search {
     throw new NotImplementedException();
   }
   @Override
-  public Search setScroll(int hitsperpage) {
+  public Search buildTermQueryWithoutTermQuery(String yesField, String yesValue, String noField, String noValue) {
     throw new NotImplementedException();
   }
   @Override

--- a/src/main/java/gov/nasa/pds/registry/common/es/dao/ProductDao.java
+++ b/src/main/java/gov/nasa/pds/registry/common/es/dao/ProductDao.java
@@ -166,7 +166,7 @@ public class ProductDao
      */
     public void updateArchiveStatus(Collection<String> lidvids, String status) throws Exception
     {
-        if(lidvids == null || status == null) return;
+        if(lidvids == null || status == null || lidvids.size() == 0) return;
         
         Request.Bulk req = client.createBulkRequest()
             .buildUpdateStatus(lidvids, status)

--- a/src/main/java/gov/nasa/pds/registry/common/es/dao/ProductDao.java
+++ b/src/main/java/gov/nasa/pds/registry/common/es/dao/ProductDao.java
@@ -2,7 +2,6 @@ package gov.nasa.pds.registry.common.es.dao;
 
 import java.net.URLEncoder;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import gov.nasa.pds.registry.common.Request;
 import gov.nasa.pds.registry.common.Response;
@@ -172,9 +171,6 @@ public class ProductDao
         Request.Bulk req = client.createBulkRequest()
             .buildUpdateStatus(lidvids, status)
             .setIndex(this.indexName);
-        System.out.println("waiting: " + new Date().toString());
-        Thread.sleep((long)(1000*1.5*3600));
-        System.out.println("released: " + new Date().toString());
         client.performRequest(req).logErrors();;
     }
     

--- a/src/main/java/gov/nasa/pds/registry/common/es/dao/ProductDao.java
+++ b/src/main/java/gov/nasa/pds/registry/common/es/dao/ProductDao.java
@@ -2,6 +2,7 @@ package gov.nasa.pds.registry.common.es.dao;
 
 import java.net.URLEncoder;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import gov.nasa.pds.registry.common.Request;
 import gov.nasa.pds.registry.common.Response;
@@ -171,7 +172,9 @@ public class ProductDao
         Request.Bulk req = client.createBulkRequest()
             .buildUpdateStatus(lidvids, status)
             .setIndex(this.indexName);
-        
+        System.out.println("waiting: " + new Date().toString());
+        Thread.sleep((long)(1000*1.5*3600));
+        System.out.println("released: " + new Date().toString());
         client.performRequest(req).logErrors();;
     }
     


### PR DESCRIPTION
## 🗒️ Summary
Couple of the calls were using the paging size instead of scroll; for instance, using `-packageId` that could generate millions of hits. Moved to scroll to handle the large volumes. Also added a reconnect to all calls so that if the access key times out (large transfer like harvest) it will reconnect then do the call again. Tries 3 times then fails.

## ⚙️ Test Data and/or Report
Ran the test where it waits for 90 minutes between DB calls. It now reconnects. Removed the delay.

## ♻️ Related Issues
Closes NASA-PDS/harvest#172
Closes NASA-PDS/registry-mgr#93



