### PR TITLE
Fix code scanning alert no. 77: Log Injection

### DIFF
--- a/src/main/java/gov/nasa/pds/registry/common/connection/es/GetRespImpl.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/es/GetRespImpl.java
@@ -153,10 +153,12 @@ class GetRespImpl implements Response.Get {
           continue;
         }
         if (stringForMissing) {
-          log.warn("Could not find datatype for field " + rec.id + ". Will use 'keyword'");
+          String sanitizedId = rec.id.replace("\n", "").replace("\r", "");
+          log.warn("Could not find datatype for field " + sanitizedId + ". Will use 'keyword'");
           dtInfo.add(new Tuple(rec.id, "keyword"));
         } else {
-          log.error("Could not find datatype for field " + rec.id);
+          String sanitizedId = rec.id.replace("\n", "").replace("\r", "");
+          log.error("Could not find datatype for field " + sanitizedId);
           missing = true;
         }
       }


### PR DESCRIPTION
Fixes [https://github.com/NASA-PDS/registry-common/security/code-scanning/77](https://github.com/NASA-PDS/registry-common/security/code-scanning/77)

To fix the log injection issue, we need to sanitize the user-provided value (`rec.id`) before logging it. This can be done by removing any potentially harmful characters, such as new-line characters, from the input. We can use the `String.replace` method to replace new-line characters with an empty string. Additionally, we should ensure that the input is clearly marked in the log entry to prevent any confusion.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
