### PR TITLE
NASA-PDS/harvest#213: Update to fix regression to skip files if already registered

### DIFF
--- a/src/main/java/gov/nasa/pds/registry/common/connection/aws/SearchRespWrap.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/aws/SearchRespWrap.java
@@ -99,7 +99,7 @@ class SearchRespWrap implements Response.Search {
       throws UnsupportedOperationException, IOException {
     HashSet<String> results = new HashSet<String>(from_ids);
     for (Hit<Object> hit : this.parent.hits().hits()) {
-      if (from_ids.contains(hit.id())) from_ids.remove(hit.id());
+      if (from_ids.contains(hit.id())) results.remove(hit.id());
     }
     return results;
   }


### PR DESCRIPTION
## 🗒️ Summary
Remove found LIDVIDs from the correct list

## ⚙️ Test Data and/or Report
harvest is once again skipping files:
```
2024-11-14 15:33:18 [SUMMARY] (HarvestCmd.java:printSummary:280) Summary:
2024-11-14 15:33:18 [SUMMARY] (HarvestCmd.java:printSummary:283) Skipped files: 69
2024-11-14 15:33:18 [SUMMARY] (HarvestCmd.java:printSummary:284) Loaded files: 0
2024-11-14 15:33:18 [SUMMARY] (HarvestCmd.java:printSummary:294) Failed files: 0
2024-11-14 15:33:18 [SUMMARY] (HarvestCmd.java:printSummary:295) Package ID: e640ce5a-e947-4d6e-9090-eb773d7d5613
```

## ♻️ Related Issues
Closes NASA-PDS/harvest#213
