### PR TITLE
Fix issue with LDD downloads on repeat. Ignore LDD if fails all retries for rest of running instance.

### DIFF
--- a/src/main/java/gov/nasa/pds/registry/common/es/service/SchemaUpdater.java
+++ b/src/main/java/gov/nasa/pds/registry/common/es/service/SchemaUpdater.java
@@ -133,8 +133,9 @@ public class SchemaUpdater
         
         try
         {
-            fileDownloader.download(jsonUrl, lddFile);
-            lddLoader.load(lddFile, schemaFileName, prefix);
+            if (fileDownloader.download(jsonUrl, lddFile)) {
+              lddLoader.load(lddFile, schemaFileName, prefix);
+            }
         }
         catch(Exception ex)
         {

--- a/src/main/java/gov/nasa/pds/registry/common/util/file/FileDownloader.java
+++ b/src/main/java/gov/nasa/pds/registry/common/util/file/FileDownloader.java
@@ -73,6 +73,7 @@ public class FileDownloader
             {
                 count++;
                 downloadOnce(fromUrl, toFile);
+                ignore.add(fromUrl);
             }
             catch(Exception ex)
             {

--- a/src/main/java/gov/nasa/pds/registry/common/util/file/FileDownloader.java
+++ b/src/main/java/gov/nasa/pds/registry/common/util/file/FileDownloader.java
@@ -3,7 +3,7 @@ package gov.nasa.pds.registry.common.util.file;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStream;
-
+import java.util.ArrayList;
 import javax.net.ssl.SSLContext;
 
 import org.apache.http.HttpEntity;
@@ -37,6 +37,7 @@ import gov.nasa.pds.registry.common.util.CloseUtils;
  */
 public class FileDownloader
 {
+  final private static ArrayList<String> ignore = new ArrayList<String>();
     private Logger log;
     private int numRetries = 3;
     
@@ -66,7 +67,7 @@ public class FileDownloader
     {
         int count = 0;
         
-        while(true)
+        while(!ignore.contains(fromUrl))
         {
             try
             {
@@ -84,7 +85,8 @@ public class FileDownloader
                 }
                 else
                 {
-                    throw new Exception("Could not download " + fromUrl);
+                  ignore.add(fromUrl);
+                  throw new Exception("Could not download " + fromUrl);
                 }
             }
         }

--- a/src/main/java/gov/nasa/pds/registry/common/util/file/FileDownloader.java
+++ b/src/main/java/gov/nasa/pds/registry/common/util/file/FileDownloader.java
@@ -63,7 +63,7 @@ public class FileDownloader
      * @param toFile Save to this file
      * @throws Exception an exception
      */
-    public void download(String fromUrl, File toFile) throws Exception
+    public boolean download(String fromUrl, File toFile) throws Exception
     {
         int count = 0;
         
@@ -73,7 +73,6 @@ public class FileDownloader
             {
                 count++;
                 downloadOnce(fromUrl, toFile);
-                return;
             }
             catch(Exception ex)
             {
@@ -90,6 +89,7 @@ public class FileDownloader
                 }
             }
         }
+        return ignore.contains(fromUrl);
     }
     
     

--- a/src/main/java/gov/nasa/pds/registry/common/util/file/FileDownloader.java
+++ b/src/main/java/gov/nasa/pds/registry/common/util/file/FileDownloader.java
@@ -86,7 +86,7 @@ public class FileDownloader
                 else
                 {
                   ignore.add(fromUrl);
-                  throw new Exception("Could not download " + fromUrl);
+                  throw new Exception("Could not download " + fromUrl + " and will not try again in this running instance.");
                 }
             }
         }


### PR DESCRIPTION
## 🗒️ Summary
Build and use an ignore list that will not retry an LDD download after trying its standard number of downloads.

## ⚙️ Test Data and/or Report
NA - cannot show an absence.

## ♻️ Related Issues
Closes NASA-PDS/harvest#205


