### PR TITLE
NASA-PDS/registry-mgr#122: add capability for list-dd

### DIFF
--- a/src/main/java/gov/nasa/pds/registry/common/connection/aws/SearchRespWrap.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/aws/SearchRespWrap.java
@@ -1,6 +1,7 @@
 package gov.nasa.pds.registry.common.connection.aws;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -96,7 +97,15 @@ class SearchRespWrap implements Response.Search {
   @Override
   public List<LddInfo> ldds() throws UnsupportedOperationException, IOException {
     ArrayList<LddInfo> results = new ArrayList<LddInfo>();
-    if (true) throw new NotImplementedException("Need to fill this out when have a return value");
+    if (parent.hits() != null) {
+      for (Hit<Object> hit : parent.hits().hits()) {
+        LddInfo item = new LddInfo();
+        Map<String,String> src = (Map<String,String>)hit.source();
+        item.namespace = src.get("attr_name");
+        item.date = Instant.parse(src.get("date"));
+        results.add(item);
+      }
+    }
     return results;
   }
   @Override


### PR DESCRIPTION
## 🗒️ Summary
Process the hits returned by search and convert them to a list of LddInfo.

## ⚙️ Test Data and/or Report
Run list-dd with -ns cart against ref data:
```
2024-12-12 09:35:28 [INFO ] (RegistryManager.java:<init>:41) Registry URL: app://connections/direct/localhost.xml

Namespace            File                                        Version   Date
-----------------------------------------------------------------------------------------------
PDS4_CART_1F00_1950.JSON null                                           null   2020-12-21T21:48:19Z
```

## ♻️ Related Issues
Closes NASA-PDS/registry-mgr#122