### PR TITLE
Fix internal harvest bug per `[ERROR] (HarvestCli.java:runCommand:98) Object builders can only be used once`

### DIFF
--- a/src/main/java/gov/nasa/pds/registry/common/es/dao/DataLoader.java
+++ b/src/main/java/gov/nasa/pds/registry/common/es/dao/DataLoader.java
@@ -243,6 +243,7 @@ public class DataLoader
               // NOTE: data list has two lines per record (primary key + data)
               loadedCount += data.size() / 2 - failedCount;
               queued = 0;
+              bulk = this.conFactory.createRestClient().createBulkRequest().setRefresh(Request.Bulk.Refresh.WaitFor).setIndex(this.conFactory.getIndexName());
             }
           }
           if (queued > 0) {


### PR DESCRIPTION
## 🗒️ Summary
create a new bulk buffer after using one.

## ⚙️ Test Data and/or Report
Reached the end without IllegalStateException.
```
2025-03-04 14:40:42 [SUMMARY] (HarvestCmd.java:printSummary:280) Summary:
2025-03-04 14:40:42 [SUMMARY] (HarvestCmd.java:printSummary:283) Skipped files: 0
2025-03-04 14:40:42 [SUMMARY] (HarvestCmd.java:printSummary:284) Loaded files: 1276
2025-03-04 14:40:42 [SUMMARY] (HarvestCmd.java:printSummary:290)   Product_Collection: 1
2025-03-04 14:40:42 [SUMMARY] (HarvestCmd.java:printSummary:290)   Product_Document: 1
2025-03-04 14:40:42 [SUMMARY] (HarvestCmd.java:printSummary:290)   Product_Observational: 1274
2025-03-04 14:40:42 [SUMMARY] (HarvestCmd.java:printSummary:294) Failed files: 0
```

## ♻️ Related Issues
Closes NASA-PDS/harvest#231

