### PR TITLE
Correctly set the page size on top hits

### DIFF
--- a/src/main/java/gov/nasa/pds/registry/common/connection/aws/SearchImpl.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/aws/SearchImpl.java
@@ -62,6 +62,7 @@ class SearchImpl implements Search {
     this.craftsman.aggregations("lids", journeyman);
     journeyman = new Aggregation.Builder()
         .topHits(new TopHitsAggregation.Builder()
+            .size(lids.size())
             .sort(new SortOptions.Builder()
                 .field(new FieldSort.Builder().field("lid").order(SortOrder.Desc).build()).build()).build()).build();
     this.craftsman.aggregations("latest", journeyman);


### PR DESCRIPTION
## 🗒️ Summary
Set the page size of top hits to be the number of lids being shoved into the aggregate.

## ⚙️ Test Data and/or Report
Using the supplied data of 106 data elements:
```
registry-manager set-archive-status -auth yours -es yours -l test_nh_docs.log -lidvid "urn:nasa:pds:nh_documents::4.0" -status archived 
2025-04-04 12:26:00 [INFO ] (ProductService.java:updateArchiveStatus:46) Setting product status and its references if bundle or collection. LIDVID = urn:nasa:pds:nh_documents::4.0, status = archived
2025-04-04 12:26:01 [INFO ] (ProductService.java:updateArchiveStatus:79) Updated a total of 106 products.
```

## ♻️ Related Issues
Closes NASA-PDS/registry-mgr#131



