### PR TITLE
Updated parent POM to take advantage of new Central Repo Portal

### DIFF
--- a/.github/workflows/stable-cicd.yaml
+++ b/.github/workflows/stable-cicd.yaml
@@ -74,8 +74,8 @@ jobs:
                     assembly: stable
                     packages: openjdk11-jdk
                 env:
-                    ossrh_username: ${{secrets.OSSRH_USERNAME}}
-                    ossrh_password: ${{secrets.OSSRH_PASSWORD}}
+                    central_portal_username: ${{secrets.CENTRAL_REPOSITORY_USERNAME}}
+                    central_portal_token: ${{secrets.CENTRAL_REPOSITORY_TOKEN}}
                     CODE_SIGNING_KEY: ${{secrets.CODE_SIGNING_KEY}}
                     ADMIN_GITHUB_TOKEN: ${{secrets.ADMIN_GITHUB_TOKEN}}
 

--- a/.github/workflows/unstable-cicd.yaml
+++ b/.github/workflows/unstable-cicd.yaml
@@ -74,8 +74,8 @@ jobs:
                     assembly: unstable
                     packages: openjdk11-jdk
                 env:
-                    ossrh_username: ${{secrets.OSSRH_USERNAME}}
-                    ossrh_password: ${{secrets.OSSRH_PASSWORD}}
+                    central_portal_username: ${{secrets.CENTRAL_REPOSITORY_USERNAME}}
+                    central_portal_token: ${{secrets.CENTRAL_REPOSITORY_TOKEN}}
                     CODE_SIGNING_KEY: ${{secrets.CODE_SIGNING_KEY}}
                     ADMIN_GITHUB_TOKEN: ${{secrets.ADMIN_GITHUB_TOKEN}}
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -85,6 +85,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -132,9 +136,9 @@
         "filename": "pom.xml",
         "hashed_secret": "fac2dea9e49a83a2d6ee38c580d1e5358b45efa5",
         "is_verified": false,
-        "line_number": 157
+        "line_number": 189
       }
     ]
   },
-  "generated_at": "2023-11-17T21:51:03Z"
+  "generated_at": "2025-06-19T20:00:34Z"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,9 @@ POSSIBILITY OF SUCH DAMAGE.
 
     <!-- Inherit release profile, reporting, SNAPSHOT repo, etc. from parent repo -->
     <parent>
-        <groupId>gov.nasa</groupId>
-        <artifactId>pds</artifactId>
-        <version>1.13.0</version>
+        <groupId>gov.nasa.pds</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.19.0</version>
     </parent>
     
     <groupId>gov.nasa.pds</groupId>


### PR DESCRIPTION
## 🗒️ Summary

The older [OSSRH is being decommissioned in favor of the new Maven Central Repository Portal](https://github.com/NASA-PDS/software-issues-repo/issues/128). The parent POM now takes advantage of it and has been published.

For this repository to do the same, it must inherit from the new parent POM. Merge this to achieve that.

## ⚙️ Test Data and/or Report

Not applicable; however any checks that fail below are likely orthogonal to this change.

## ♻️ Related Issues

- https://github.com/NASA-PDS/software-issues-repo/issues/128
- https://github.com/NASA-PDS/software-issues-repo/issues/131
