### PR TITLE
harvest 265: more complete date time handler

### DIFF
--- a/src/main/java/gov/nasa/pds/registry/common/dd/LddUtils.java
+++ b/src/main/java/gov/nasa/pds/registry/common/dd/LddUtils.java
@@ -3,8 +3,12 @@ package gov.nasa.pds.registry.common.dd;
 import java.io.File;
 import java.text.ParseException;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +30,8 @@ public class LddUtils
 {
     private static final Map<String, List<Pattern>> Accepted_LDD_DateFormats = new TreeMap<String,List<Pattern>>();
     static {
+      Accepted_LDD_DateFormats.put("u[-D]",TimeFormatRegex.DOY_FORMATS);
+      Accepted_LDD_DateFormats.put("u[-M[-d]]",TimeFormatRegex.DATE_YMD_FORMATS);
       Accepted_LDD_DateFormats.put("u[-D['T'H[:m[:s[.S]]]]]X",TimeFormatRegex.DATE_TIME_DOY_FORMATS);
       Accepted_LDD_DateFormats.put("u[-M[-d['T'H[:m[:s[.S]]]]]]X",TimeFormatRegex.DATE_TIME_YMD_FORMATS);
       Accepted_LDD_DateFormats.put("H[:m[:s[.S]]]X",TimeFormatRegex.TIME_FORMATS);
@@ -69,19 +75,33 @@ public class LddUtils
     }
     public static Date parseLddDate(String dateStr, @Nonnull String handleLeapSecondNotation) throws ParseException {
     String cleaned = dateStr.trim();
+    boolean hasTime = cleaned.contains(":");
     for (String pattern : Accepted_LDD_DateFormats.keySet()) {
       for (Pattern regex : Accepted_LDD_DateFormats.get(pattern)) {
         if (regex.matcher(cleaned).matches()) {
-          cleaned = (cleaned + "Z").replace("ZZ", "Z");
-          if (!handleLeapSecondNotation.isBlank()) {
-            cleaned = cleaned.replace(":60", handleLeapSecondNotation);
+          if (pattern.contains(":") && hasTime) {
+            cleaned = (cleaned + "Z").replace("ZZ", "Z");
+            if (!handleLeapSecondNotation.isBlank()) {
+              cleaned = cleaned.replace(":60", handleLeapSecondNotation);
+            }
+            pattern = subseconds(cleaned, pattern);
+            return Date.from(
+                ZonedDateTime.parse(
+                    cleaned,
+                    DateTimeFormatter.ofPattern(pattern))
+                .toInstant());
+          } else if (!pattern.contains(":") && !hasTime) {
+            DateTimeFormatterBuilder dtfb = new DateTimeFormatterBuilder()
+                .appendPattern(pattern);
+            if (pattern.contains("-D")) {
+              dtfb.parseDefaulting(ChronoField.DAY_OF_YEAR, 1);
+            } else {
+              dtfb.parseDefaulting(ChronoField.MONTH_OF_YEAR, 1);
+              dtfb.parseDefaulting(ChronoField.DAY_OF_MONTH, 1);
+            }
+            LocalDate when = LocalDate.parse(cleaned,dtfb.toFormatter());
+            return Date.from(when.atStartOfDay(ZoneId.of("Z")).toInstant());
           }
-          pattern = subseconds(cleaned, pattern);
-          return Date.from(
-              ZonedDateTime.parse(
-                  cleaned,
-                  DateTimeFormatter.ofPattern(pattern))
-              .toInstant());
         }
       }
     }


### PR DESCRIPTION
## 🗒️ Summary
Have to handle dates differently than date times. Leap seconds worked otherwise.

## ⚙️ Test Data and/or Report
Ran harvest using NASA-PDS/registry#15 branch:
```
2025-08-27 13:04:00 [SUMMARY] (HarvestCmd.java:readConfigFile:190) Reading configuration from /home/niessner/Projects/PDS/registry-ref-data/custom-datasets/ls.xml
2025-08-27 13:04:01 [SUMMARY] (HarvestCmd.java:initWriterManager:179) Output directory: /tmp/harvest/out
2025-08-27 13:04:01 [SUMMARY] (RegistryManager.java:<init>:57) Connection: gov.nasa.pds.registry.common.connection.UseOpensearchSDK2@6b6776cb
2025-08-27 13:04:01 [INFO ] (HarvestCmd.java:configure:154) Connecting to Elasticsearch
2025-08-27 13:04:02 [INFO ] (Pds2EsDataTypeMap.java:load:93) Loading PDS to ES data type mapping from /home/niessner/Projects/PDS/harvest/target/classes/elastic/data-dic-types.cfg
2025-08-27 13:04:02 [INFO ] (HarvestCmd.java:processDirectory:221) Processing directory: /home/niessner/Projects/PDS/registry-ref-data/custom-datasets/test/registry426
2025-08-27 13:04:02 [INFO ] (FilesProcessor.java:processMetadata:191) Processing /home/niessner/Projects/PDS/registry-ref-data/custom-datasets/test/registry426/leap_second_test.xml
2025-08-27 13:04:03 [INFO ] (MetadataWriter.java:writeBatch:106) Wrote 1 product(s)
2025-08-27 13:04:03 [SUMMARY] (HarvestCmd.java:printSummary:282) Summary:
2025-08-27 13:04:03 [SUMMARY] (HarvestCmd.java:printSummary:285) Skipped files: 0
2025-08-27 13:04:03 [SUMMARY] (HarvestCmd.java:printSummary:286) Loaded files: 1
2025-08-27 13:04:03 [SUMMARY] (HarvestCmd.java:printSummary:292)   Product_Observational: 1
2025-08-27 13:04:03 [SUMMARY] (HarvestCmd.java:printSummary:296) Failed files: 0
2025-08-27 13:04:03 [SUMMARY] (HarvestCmd.java:printSummary:297) Package ID: e13888b1-d4a9-4ad5-b378-e231a8d59abf
```

## ♻️ Related Issues
Closes NASA-PDS/harvest#265


