### PR TITLE
fix latest lidvid

### DIFF
--- a/src/main/java/gov/nasa/pds/registry/common/connection/aws/GetRespWrap.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/aws/GetRespWrap.java
@@ -30,7 +30,7 @@ class GetRespWrap implements Response.Get {
     if (this.parent.source() != null) {
       Map<String,List<String>> src = (Map<String,List<String>>)this.parent.source();
       if (src.containsKey("ref_lid_collection")) result.lids.addAll(src.get("ref_lid_collection"));
-      if (src.containsKey("ref_lidvid_collection")) result.lids.addAll(src.get("ref_lidvid_collection"));
+      if (src.containsKey("ref_lidvid_collection")) result.lidvids.addAll(src.get("ref_lidvid_collection"));
     }
     return result;
   }


### PR DESCRIPTION
## 🗒️ Summary
Update the lid/livid parsing to fix problems with the archive status in regsitry manager.

## ⚙️ Test Data and/or Report
Used the test data from NASA-PDS/registry-mgr#137 to fix both problems. Here is the answer for the test data:
```
Setting product status and its references if bundle or collection. LIDVID = urn:nasa:pds:soho::1.3, status = archived

Updated a total of 103 products.
```

## ♻️ Related Issues
Closes NASA-PDS/registry-mgr#134
Closes NASA-PDS/registry-mgr#137
