### PR TITLE
Revert ops:Harvest_Meta rename back to ops:Harvest_Info

### DIFF
--- a/src/main/java/gov/nasa/pds/registry/common/meta/Metadata.java
+++ b/src/main/java/gov/nasa/pds/registry/common/meta/Metadata.java
@@ -15,9 +15,9 @@ import gov.nasa.pds.registry.common.util.FieldMapSet;
  */
 public class Metadata {
   public static final String FLD_ALTERNATE_IDS = "alternate_ids";
-  public static final String FLD_NODE_NAME = "ops:Harvest_Meta/ops:node_name";
-  public static final String FLD_HARVEST_DATE_TIME = "ops:Harvest_Meta/ops:harvest_date_time";
-  public static final String FLD_HARVEST_VERSION = "ops:Harvest_Meta/ops:harvest_version";
+  public static final String FLD_NODE_NAME = "ops:Harvest_Info/ops:node_name";
+  public static final String FLD_HARVEST_DATE_TIME = "ops:Harvest_Info/ops:harvest_date_time";
+  public static final String FLD_HARVEST_VERSION = "ops:Harvest_Info/ops:harvest_version";
   public static final String FLD_ARCHIVE_STATUS = "ops:Tracking_Meta/ops:archive_status";
 
 


### PR DESCRIPTION
## Summary
- Reverts the rename of `ops:Harvest_Info` fields to `ops:Harvest_Meta` introduced in commit 47c08128
- Restores backward compatibility with existing `registry-mgr` index mappings which still use `ops:Harvest_Info`
- The rename caused `DataTypeNotFoundException` in Harvest when looking up field data types in the registry-dd index

## Test plan
- [ ] Verify `mvn clean install` passes
- [ ] Run Harvest against a PDS4 dataset and confirm no `DataTypeNotFoundException` errors for `ops:Harvest_Info/*` fields

## Related Issues
Fixes NASA-PDS/harvest#316
Reverts 47c08128b4af8bdf725227023a44c6ca5151018d (part of #132)

> 🤖 Generated with [Claude Code](https://claude.ai/claude-code)