### PR TITLE
Resolve ops: field types from built-in map; fail on unresolvable LDD namespace; add forceLoad flag

### DIFF
--- a/src/main/java/gov/nasa/pds/registry/common/es/service/SchemaUpdater.java
+++ b/src/main/java/gov/nasa/pds/registry/common/es/service/SchemaUpdater.java
@@ -3,6 +3,8 @@ package gov.nasa.pds.registry.common.es.service;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -21,6 +23,7 @@ import gov.nasa.pds.registry.common.es.dao.dd.DataDictionaryDao;
 import gov.nasa.pds.registry.common.ConnectionFactory;
 import gov.nasa.pds.registry.common.es.dao.schema.SchemaDao;
 import gov.nasa.pds.registry.common.es.dao.dd.LddVersions;
+import gov.nasa.pds.registry.common.meta.OpsFields;
 
 
 /**
@@ -87,10 +90,25 @@ public class SchemaUpdater {
       }
     }
 
-    // Update schema
+    // Update schema: resolve ops: fields from built-in map, all others from the -dd index
     if (fields != null && !fields.isEmpty()) {
-      List<Tuple> newFields = ddDao.getDataTypes(fields);
-      if (newFields != null) {
+      List<Tuple> newFields = new ArrayList<>();
+      Set<String> ddFields = new HashSet<>();
+      for (String field : fields) {
+        String opsType = OpsFields.FIELD_TYPES.get(field);
+        if (opsType != null) {
+          newFields.add(new Tuple(field, opsType));
+        } else {
+          ddFields.add(field);
+        }
+      }
+      if (!ddFields.isEmpty()) {
+        List<Tuple> ddTypes = ddDao.getDataTypes(ddFields);
+        if (ddTypes != null) {
+          newFields.addAll(ddTypes);
+        }
+      }
+      if (!newFields.isEmpty()) {
         schemaDao.updateSchema(newFields);
         log.debug("Updated " + newFields.size() + " fields in OpenSearch mapping for index "
             + this.index);

--- a/src/main/java/gov/nasa/pds/registry/common/es/service/SchemaUpdater.java
+++ b/src/main/java/gov/nasa/pds/registry/common/es/service/SchemaUpdater.java
@@ -40,6 +40,11 @@ public class SchemaUpdater {
   private SchemaDao schemaDao;
 
   final private String index;
+  private boolean forceLoad = false;
+
+  public void setForceLoad(boolean forceLoad) {
+    this.forceLoad = forceLoad;
+  }
 
   /**
    * Constructor
@@ -83,6 +88,8 @@ public class SchemaUpdater {
 
         try {
           updateLdd(uri, prefix);
+        } catch (LddException ex) {
+          throw ex;
         } catch (Exception ex) {
           log.error("Could not update LDD for namespace '" + prefix + "' at URI " + uri
               + ": " + ex.getMessage() + ". Harvesting will continue with available field definitions.");
@@ -175,8 +182,12 @@ public class SchemaUpdater {
       Thread.currentThread().interrupt();
       log.error("Interrupted while downloading or loading LDD for namespace '" + prefix + "' from " + jsonUrl);
       if (lddInfo.isEmpty()) {
-        log.warn("No previously loaded LDD found for namespace '" + prefix
-            + "'. Fields from this namespace will use 'keyword' data type.");
+        if (!forceLoad) {
+          throw new LddException("No previously loaded LDD found for namespace '" + prefix
+              + "'. Cannot load products with fields from this namespace.");
+        }
+        log.warn("Force mode: no LDD found for namespace '" + prefix
+            + "'. Fields from this namespace will not be indexed.");
       } else {
         log.warn("Will use previously loaded field definitions for namespace '" + prefix
             + "' from " + lddInfo.files);
@@ -186,8 +197,12 @@ public class SchemaUpdater {
       log.error("Failed to download or load LDD for namespace '" + prefix + "' from " + jsonUrl
           + ": " + ExceptionUtils.getMessage(ex));
       if (lddInfo.isEmpty()) {
-        log.warn("No previously loaded LDD found for namespace '" + prefix
-            + "'. Fields from this namespace will use 'keyword' data type.");
+        if (!forceLoad) {
+          throw new LddException("No previously loaded LDD found for namespace '" + prefix
+              + "'. Cannot load products with fields from this namespace.");
+        }
+        log.warn("Force mode: no LDD found for namespace '" + prefix
+            + "'. Fields from this namespace will not be indexed.");
       } else {
         log.warn("Will use previously loaded field definitions for namespace '" + prefix
             + "' from " + lddInfo.files);

--- a/src/main/java/gov/nasa/pds/registry/common/meta/OpsFields.java
+++ b/src/main/java/gov/nasa/pds/registry/common/meta/OpsFields.java
@@ -1,0 +1,36 @@
+package gov.nasa.pds.registry.common.meta;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Canonical ES type mapping for all ops: namespace fields. These are Harvest-internal operational
+ * fields whose types are defined here rather than in the registry-dd index.
+ */
+public class OpsFields {
+  public static final Map<String, String> FIELD_TYPES;
+
+  static {
+    Map<String, String> map = new HashMap<>();
+    map.put("ops:Harvest_Info/ops:node_name", "keyword");
+    map.put("ops:Harvest_Info/ops:harvest_date_time", "date");
+    map.put("ops:Harvest_Info/ops:harvest_version", "keyword");
+    map.put("ops:Tracking_Meta/ops:archive_status", "keyword");
+    map.put("ops:Provenance/ops:superseded_by", "keyword");
+    map.put("ops:Label_File_Info/ops:creation_date_time", "date");
+    map.put("ops:Label_File_Info/ops:file_ref", "keyword");
+    map.put("ops:Label_File_Info/ops:file_name", "keyword");
+    map.put("ops:Label_File_Info/ops:file_size", "long");
+    map.put("ops:Label_File_Info/ops:md5_checksum", "keyword");
+    map.put("ops:Label_File_Info/ops:blob", "binary");
+    map.put("ops:Label_File_Info/ops:json_blob", "binary");
+    map.put("ops:Data_File_Info/ops:creation_date_time", "date");
+    map.put("ops:Data_File_Info/ops:file_ref", "keyword");
+    map.put("ops:Data_File_Info/ops:file_name", "keyword");
+    map.put("ops:Data_File_Info/ops:file_size", "long");
+    map.put("ops:Data_File_Info/ops:md5_checksum", "keyword");
+    map.put("ops:Data_File_Info/ops:mime_type", "keyword");
+    FIELD_TYPES = Collections.unmodifiableMap(map);
+  }
+}


### PR DESCRIPTION
## 🗒️ Summary

This PR bundles two related fixes to `SchemaUpdater`:

### 1. Resolve `ops:` field types from built-in map (fixes NASA-PDS/registry-loader#68)

Adds `OpsFields.java` with a canonical field→ES type map for all `ops:` namespace fields and updates `SchemaUpdater.updateSchema()` to resolve `ops:` fields from that map instead of the `-dd` index.

`ops:` fields are Harvest-internal operational fields (e.g. `ops:Harvest_Info/ops:harvest_version`) with fixed, known ES types. They are never stored in the `registry-dd` index. The previous code sent all missing schema fields — including `ops:` ones — to `DataDictionaryDao.getDataTypes()`, which queries `-dd`. For any registry created before an `ops:` field was added (e.g. `ops:harvest_version` added Aug 2023), this caused `DataTypeNotFoundException` and halted product loading.

The fix partitions field resolution in `updateSchema()`:
- `ops:` fields → resolved from `OpsFields.FIELD_TYPES` static map
- All other fields → resolved from the `-dd` index as before

### 2. Fail product loading when LDD namespace cannot be resolved; support `forceLoad` flag (fixes NASA-PDS/registry-loader#65, NASA-PDS/registry-loader#66)

When an LDD cannot be downloaded and no previously cached version exists in the data dictionary index, `SchemaUpdater` now throws `LddException` instead of silently falling back to `keyword` data type. This causes the product to fail loading with a clear ERROR message (`failedFileCount++`), consistent with the per-attribute-type fix from PR #112.

A new `forceLoad` flag (set via `setForceLoad()`) opts in to lenient behavior: the product still loads but fields from the unresolvable namespace are omitted from the schema and not indexed. Keyword is **never** used as a fallback under any circumstances.

### 🤖 AI Assistance Disclosure
- [ ] No AI assistance used
- [ ] AI used for light assistance (e.g., suggestions, refactoring, documentation help, minor edits)
- [ ] AI used for moderate content generation (AI generated some code or logic, but the developer authored or heavily revised the majority)
- [x] AI generated substantial portions of this code

Estimated % of code influenced by AI: 90%

## ⚙️ Test Data and/or Report

Manual verification: ran Harvest against a registry initialized before `ops:harvest_version` was added. Previously failed with `DataTypeNotFoundException`; with this fix the field is resolved from `OpsFields.FIELD_TYPES` and the schema is updated correctly.

No automated tests added — existing test infrastructure for `SchemaUpdater` and `DataDictionaryDao` covers the non-ops path.

## ♻️ Related Issues

Fixes NASA-PDS/registry-loader#68
Fixes NASA-PDS/registry-loader#65
Fixes NASA-PDS/registry-loader#66

## 🤓 Reviewer Checklist

*Reviewers: Please verify the following before approving this pull request.*

### Documentation and PR Content
- [ ] **Documentation:** README, Wiki, or inline documentation (Sphinx, Javadoc, Docstrings) have been updated to reflect these changes.
- [ ] **Issue Traceability:** The PR is linked to a valid GitHub Issue
- [ ] **PR Title:** The PR title is "user-friendly" clearly identifying what is being fixed or the new feature being added, that if you saw it in the Release Notes for a tool, you would be able to get the gist of what was done.

### Security & Quality
- [ ] **SonarCloud:** Confirmed no new High or Critical security findings.
- [ ] **Secrets Detection:** Verified that the Secrets Detection scan passed and no sensitive information (keys, tokens, PII) is exposed.
- [ ] **Code Quality:** Code follows organization style guidelines and best practices for the specific language (e.g., PEP 8, Google Java Style).

### Testing & Validation
- [ ] **Test Accuracy:** Verified that test data is accurate, representative of real-world PDS4 scenarios, and sufficient for the logic being tested.
- [ ] **Coverage:** Automated tests cover new logic and edge cases.
- [ ] **Local Verification:** (If applicable) Successfully built and ran the changes in a local or staging environment.

### Maintenance
- [ ] **Backward Compatibility:** Confirmed that these changes do not break existing downstream dependencies or API contracts (or that breaking changes are clearly documented).