### PR TITLE
Fallback to pds.nasa.gov mirror when third-party LDD URL is unreachable

### DIFF
--- a/src/main/java/gov/nasa/pds/registry/common/es/service/LddUrlUtils.java
+++ b/src/main/java/gov/nasa/pds/registry/common/es/service/LddUrlUtils.java
@@ -1,0 +1,34 @@
+package gov.nasa.pds.registry.common.es.service;
+
+import java.net.URL;
+
+/**
+ * Utility methods for resolving LDD download URLs.
+ */
+public class LddUrlUtils
+{
+    static final String PDS_NASA_GOV = "pds.nasa.gov";
+
+    private LddUrlUtils() {}
+
+    /**
+     * Build the pds.nasa.gov mirror URL by replacing the host.
+     * Returns null if the URL is already from pds.nasa.gov or cannot be parsed.
+     */
+    public static String toPdsNasaGovUrl(String url)
+    {
+        try
+        {
+            URL parsed = new URL(url);
+            if(PDS_NASA_GOV.equals(parsed.getHost()))
+            {
+                return null;
+            }
+            return "https://" + PDS_NASA_GOV + parsed.getPath();
+        }
+        catch(Exception e)
+        {
+            return null;
+        }
+    }
+}

--- a/src/main/java/gov/nasa/pds/registry/common/es/service/SchemaUpdater.java
+++ b/src/main/java/gov/nasa/pds/registry/common/es/service/SchemaUpdater.java
@@ -3,6 +3,8 @@ package gov.nasa.pds.registry.common.es.service;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -29,6 +31,10 @@ import gov.nasa.pds.registry.common.es.dao.dd.LddVersions;
  * @author karpenko
  */
 public class SchemaUpdater {
+  // Cached domain redirects: if a non-pds.nasa.gov host fails but its pds.nasa.gov
+  // mirror succeeds, future requests from that host go directly to pds.nasa.gov.
+  static final Map<String, String> domainRedirects = new HashMap<>();
+
   private Logger log;
   private FileDownloader fileDownloader;
   private JsonLddLoader lddLoader;
@@ -107,8 +113,8 @@ public class SchemaUpdater {
 
     log.info("Updating '" + prefix + "' LDD. Schema location: " + uri);
 
-    // Get JSON schema URL from XSD URL
-    String jsonUrl = getJsonUrl(uri);
+    // Get JSON schema URL from XSD URL, applying any cached domain redirect
+    String jsonUrl = applyDomainRedirect(getJsonUrl(uri));
 
     // Get schema file name
     int idx = jsonUrl.lastIndexOf('/');
@@ -165,6 +171,25 @@ public class SchemaUpdater {
       }
       return;
     } catch (Exception ex) {
+      String fallbackUrl = LddUrlUtils.toPdsNasaGovUrl(jsonUrl);
+      if (fallbackUrl != null) {
+        log.warn("Failed to download LDD from " + jsonUrl + "; trying pds.nasa.gov mirror: " + fallbackUrl);
+        boolean mirrorSuccess = false;
+        try {
+          if (fileDownloader.download(fallbackUrl, lddFile)) {
+            String originalHost = new URL(jsonUrl).getHost();
+            domainRedirects.put(originalHost, LddUrlUtils.PDS_NASA_GOV);
+            log.info("Caching domain redirect: " + originalHost + " -> " + LddUrlUtils.PDS_NASA_GOV);
+            lddLoader.load(lddFile, schemaFileName, prefix);
+            mirrorSuccess = true;
+          }
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
+        } catch (Exception fallbackEx) {
+          log.debug("pds.nasa.gov mirror also failed: " + fallbackEx.getMessage());
+        }
+        if (mirrorSuccess) return;
+      }
       log.error("Failed to download or load LDD for namespace '" + prefix + "' from " + jsonUrl
           + ": " + ExceptionUtils.getMessage(ex));
       if (lddInfo.isEmpty()) {
@@ -186,6 +211,27 @@ public class SchemaUpdater {
     } else {
       throw new IllegalArgumentException("Invalid schema URI - does not end with '.xsd': " + uri);
     }
+  }
+
+
+  /**
+   * Apply any cached domain redirect to a URL. If the URL's host has a known
+   * redirect (e.g. isda.issdc.gov.in → pds.nasa.gov), return the rewritten URL.
+   */
+  private String applyDomainRedirect(String url) {
+    try {
+      String host = new URL(url).getHost();
+      if (domainRedirects.containsKey(host)) {
+        String redirected = LddUrlUtils.toPdsNasaGovUrl(url);
+        if (redirected != null) {
+          log.debug("Redirecting " + url + " to " + redirected + " (cached domain redirect)");
+          return redirected;
+        }
+      }
+    } catch (Exception e) {
+      // fall through and return original
+    }
+    return url;
   }
 
 }

--- a/src/test/java/service/TestLddUrlUtils.java
+++ b/src/test/java/service/TestLddUrlUtils.java
@@ -1,0 +1,38 @@
+package service;
+
+import gov.nasa.pds.registry.common.es.service.LddUrlUtils;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestLddUrlUtils
+{
+    @Test
+    public void thirdPartyUrlIsRewritten()
+    {
+        String input    = "https://isda.issdc.gov.in/pds4/isda/v1/ch2_ldd_ISDA_1000.JSON";
+        String expected = "https://pds.nasa.gov/pds4/isda/v1/ch2_ldd_ISDA_1000.JSON";
+        assertEquals(expected, LddUrlUtils.toPdsNasaGovUrl(input));
+    }
+
+    @Test
+    public void pdsNasaGovUrlReturnsNull()
+    {
+        String input = "https://pds.nasa.gov/pds4/isda/v1/ch2_ldd_ISDA_1000.JSON";
+        assertNull(LddUrlUtils.toPdsNasaGovUrl(input));
+    }
+
+    @Test
+    public void invalidUrlReturnsNull()
+    {
+        assertNull(LddUrlUtils.toPdsNasaGovUrl("not-a-url"));
+        assertNull(LddUrlUtils.toPdsNasaGovUrl(null));
+    }
+
+    @Test
+    public void xsdExtensionPathIsPreserved()
+    {
+        String input    = "https://other.agency.gov/pds4/ns/v1/schema.xsd";
+        String expected = "https://pds.nasa.gov/pds4/ns/v1/schema.xsd";
+        assertEquals(expected, LddUrlUtils.toPdsNasaGovUrl(input));
+    }
+}


### PR DESCRIPTION
## 🗒️ Summary

When harvesting, LDD JSON files referenced by third-party schema URLs (e.g. `isda.issdc.gov.in`) are sometimes unreachable. Previously this produced a non-recoverable error with no fallback. This PR adds a two-stage fallback:

1. **Mirror retry** — if a non-`pds.nasa.gov` LDD URL fails, `SchemaUpdater` attempts the equivalent `pds.nasa.gov` URL (same path, host replaced).
2. **Domain redirect cache** — on a successful mirror hit, the source host is cached so all subsequent requests for that domain bypass the failing origin entirely.
3. **Graceful degradation** — if the mirror also fails, existing error-handling is preserved (keyword type, previously loaded LDDs).

**New class:** `LddUrlUtils` — extracts the URL rewriting logic into a standalone testable utility.

**Tests:** 4 new unit tests in `TestLddUrlUtils` (all passing).

> 🤖 This PR was generated with the assistance of [Claude Code](https://claude.ai/claude-code). Approximately 80% of the code changes were AI-influenced.

## ⚙️ Test Data and/or Report

Unit tests run via `mvn test`:

```
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
```

Test cases cover:
- Third-party URL correctly rewritten to `pds.nasa.gov` mirror
- `pds.nasa.gov` URL returns `null` (no rewrite needed)
- Invalid / null input returns `null` safely
- Non-JSON paths (e.g. `.xsd`) are also rewritten correctly

Integration testing with a live harvest run against a label referencing `isda.issdc.gov.in` LDDs is recommended before merge.

## ♻️ Related Issues

Closes #279

## 🤓 Reviewer Checklist

- [ ] Are there new requirements this should close?
- [ ] Does the bug fix include a regression test?
- [ ] Is the documentation up to date?
- [ ] Is this backwards compatible?
- [ ] Are security concerns addressed?
- [ ] Is the CI/CD pipeline correctly configured?
