### PR TITLE
Fix force mode: preserve found field types when DataTypeNotFoundException is partial

### DIFF
--- a/src/main/java/gov/nasa/pds/registry/common/connection/aws/MGetRespWrap.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/aws/MGetRespWrap.java
@@ -17,7 +17,7 @@ class MGetRespWrap extends GetRespWrap {
   }
   @Override
   public List<Tuple> dataTypes() throws IOException, DataTypeNotFoundException {
-    boolean stillMissing = false;
+    ArrayList<String> missing = new ArrayList<String>();
     ArrayList<Tuple> results = new ArrayList<Tuple>();
     for (MultiGetResponseItem<Object> doc : this.parent.docs()) {
       Tuple t = null;
@@ -32,13 +32,12 @@ class MGetRespWrap extends GetRespWrap {
             log.warn("Could not find datatype for field {} and defaulting to 'text'", doc.result().id());
             t = new Tuple(doc.result().id(), "text");
         } else {
-          stillMissing = true;
-          log.error("Could not find the data type for the field {}", doc.result().id());
+          missing.add(doc.result().id());
         }
       }
       if (t != null) results.add(t);
     }
-    if (stillMissing) throw new DataTypeNotFoundException();
+    if (!missing.isEmpty()) throw new DataTypeNotFoundException(missing, results);
     return results;
   }
 }

--- a/src/main/java/gov/nasa/pds/registry/common/connection/es/GetRespImpl.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/es/GetRespImpl.java
@@ -132,17 +132,13 @@ class GetRespImpl implements Response.Get {
   @Override
   public List<Tuple> dataTypes() throws IOException, DataTypeNotFoundException {
     List<Tuple> dtInfo = new ArrayList<Tuple>();
+    List<String> missing = new ArrayList<String>();
     GetDataTypesResponseParser parser = new GetDataTypesResponseParser();
     List<GetDataTypesResponseParser.Record> records = parser.parse(this.response.getEntity());
-    // Process response (list of fields)
-    boolean missing = false;
     for (GetDataTypesResponseParser.Record rec : records) {
       if (rec.found) {
         dtInfo.add(new Tuple(rec.id, rec.esDataType));
-      }
-      // There is no data type for this field in ES registry-dd index
-      else {
-        // Automatically assign data type for known fields
+      } else {
         if (rec.id.startsWith("ref_lid_") || rec.id.startsWith("ref_lidvid_")
             || rec.id.endsWith("_Area")) {
           dtInfo.add(new Tuple(rec.id, "keyword"));
@@ -152,13 +148,12 @@ class GetRespImpl implements Response.Get {
           log.warn("Could not find datatype for field " + rec.id + ". Will use 'text'");
           dtInfo.add(new Tuple(rec.id, "text"));
         } else {
-          log.error("Could not find datatype for field " + rec.id);
-          missing = true;
+          missing.add(rec.id);
         }
       }
     }
-    if (missing == true)
-      throw new DataTypeNotFoundException();
+    if (!missing.isEmpty())
+      throw new DataTypeNotFoundException(missing, dtInfo);
 
     return dtInfo;
   }

--- a/src/main/java/gov/nasa/pds/registry/common/es/dao/dd/DataTypeNotFoundException.java
+++ b/src/main/java/gov/nasa/pds/registry/common/es/dao/dd/DataTypeNotFoundException.java
@@ -1,32 +1,57 @@
 package gov.nasa.pds.registry.common.es.dao.dd;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import gov.nasa.pds.registry.common.util.Tuple;
+
 /**
- *  Throw this exception when the data type for a new registry field 
- *  is not found in the data dictionary and Elasticsearch schema 
+ *  Throw this exception when the data type for a new registry field
+ *  is not found in the data dictionary and Elasticsearch schema
  *  could not be updated.
- *  
+ *
  * @author karpenko
  */
 @SuppressWarnings("serial")
 public class DataTypeNotFoundException extends Exception
 {
-    private static final String LINK 
+    private static final String LINK
         = "See 'https://nasa-pds.github.io/pds-registry-app/operate/common-ops.html#Load' for more information.";
-    
-    /**
-     * Constructor
-     */
+
+    private final List<String> missingFields;
+    private final List<Tuple> foundTypes;
+
     public DataTypeNotFoundException()
     {
         super("Could not find datatype(s). " + LINK);
+        this.missingFields = Collections.emptyList();
+        this.foundTypes = Collections.emptyList();
     }
-    
-    /**
-     * Constructor
-     * @param fieldName Elasticsearch field name
-     */
+
+    public DataTypeNotFoundException(Collection<String> missingFields, List<Tuple> foundTypes)
+    {
+        super("Could not find datatype(s). " + LINK);
+        this.missingFields = Collections.unmodifiableList(List.copyOf(missingFields));
+        this.foundTypes = foundTypes != null
+            ? Collections.unmodifiableList(List.copyOf(foundTypes))
+            : Collections.emptyList();
+    }
+
     public DataTypeNotFoundException(String fieldName)
     {
         super("Could not find datatype for field '" + fieldName + "'. " + LINK);
+        this.missingFields = Collections.singletonList(fieldName);
+        this.foundTypes = Collections.emptyList();
+    }
+
+    public List<String> getMissingFields()
+    {
+        return missingFields;
+    }
+
+    public List<Tuple> getFoundTypes()
+    {
+        return foundTypes;
     }
 }

--- a/src/main/java/gov/nasa/pds/registry/common/es/service/SchemaUpdater.java
+++ b/src/main/java/gov/nasa/pds/registry/common/es/service/SchemaUpdater.java
@@ -20,6 +20,7 @@ import gov.nasa.pds.registry.common.util.file.FileDownloader;
 import gov.nasa.pds.registry.common.util.Tuple;
 
 import gov.nasa.pds.registry.common.es.dao.dd.DataDictionaryDao;
+import gov.nasa.pds.registry.common.es.dao.dd.DataTypeNotFoundException;
 import gov.nasa.pds.registry.common.ConnectionFactory;
 import gov.nasa.pds.registry.common.es.dao.schema.SchemaDao;
 import gov.nasa.pds.registry.common.es.dao.dd.LddVersions;
@@ -110,9 +111,22 @@ public class SchemaUpdater {
         }
       }
       if (!ddFields.isEmpty()) {
-        List<Tuple> ddTypes = ddDao.getDataTypes(ddFields);
-        if (ddTypes != null) {
-          newFields.addAll(ddTypes);
+        try {
+          List<Tuple> ddTypes = ddDao.getDataTypes(ddFields);
+          if (ddTypes != null) {
+            newFields.addAll(ddTypes);
+          }
+        } catch (DataTypeNotFoundException ex) {
+          if (!forceLoad) {
+            for (String f : ex.getMissingFields()) {
+              log.error("Could not find the data type for the field {}", f);
+            }
+            throw ex;
+          }
+          log.warn("Force mode: could not find data types for fields {} - these fields will not be indexed or searchable. Product will still be ingested.", ex.getMissingFields());
+          if (!ex.getFoundTypes().isEmpty()) {
+            newFields.addAll(ex.getFoundTypes());
+          }
         }
       }
       if (!newFields.isEmpty()) {


### PR DESCRIPTION
## 🗒️ Summary

Follow-on fix to #278. When `getDataTypes()` encounters a batch of fields and only some are missing from the dd index, `DataTypeNotFoundException` was thrown — discarding the found-field types along with the missing ones. In force mode, `SchemaUpdater` caught the exception but couldn't recover the found types, so even resolvable fields failed to get their schema mappings updated.

### Root cause

`GetRespImpl.dataTypes()` and `MGetRespWrap.dataTypes()` built up a `dtInfo` list of found types and a `missing` list of unresolved field names, then threw `DataTypeNotFoundException(missing)` — but `dtInfo` was a local variable that was discarded with the exception. The exception only carried the missing names.

### Fix

1. **`DataTypeNotFoundException`** — adds a `foundTypes: List<Tuple>` field alongside `missingFields`, with a new `DataTypeNotFoundException(Collection<String> missingFields, List<Tuple> foundTypes)` constructor and `getFoundTypes()` accessor.

2. **`GetRespImpl.dataTypes()` / `MGetRespWrap.dataTypes()`** — now pass the accumulated `dtInfo`/`results` to the exception so callers can recover them.

3. **`SchemaUpdater.updateSchema()`** — in force mode, after catching `DataTypeNotFoundException`, recovers `ex.getFoundTypes()` and adds those types to `newFields` so resolvable fields still get their schema mappings.

No-force behavior is unchanged: the exception is still re-thrown after logging missing fields.

### 🤖 AI Assistance Disclosure
- [x] AI generated substantial portions of this code

Estimated % of code influenced by AI: 90%

## Manual Testing
Using test data: [harvest-sbn.zip](https://github.com/user-attachments/files/28519858/harvest-sbn.zip)

```
# Install registry-common
$ cd registry-common && mvn clean install

# Build harvest with new registry-common
$ cd harvest && mvn clean package

# After unpacking the harvest package
# Setup config file pointing to an online registry
# Run harvest
$ harvest-5.2.0-SNAPSHOT/bin/harvest -c /path/to/.pds/registry-harvest-config-test-sbn.xml  --archive-status archived --force
...
2026-06-02 10:23:27 [ERROR] (SchemaUpdater.java:updateLdd:211) Failed to download or load LDD for namespace 'pds' from https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1J00.JSON: Failed to upload all documents (0/100) to -dd
2026-06-02 10:23:27 [WARN ] (SchemaUpdater.java:updateLdd:221) Will use previously loaded field definitions for namespace 'pds' from [PDS4_PDS_1F00.JSON, PDS4_PDS_1I00.JSON, PDS4_PDS_1L00.JSON, PDS4_PDS_1M00.JSON, PDS4_PDS_1N00.JSON, PDS4_PDS_1O00.JSON, PDS4_PDS_1P00.JSON]
2026-06-02 10:23:27 [WARN ] (SchemaUpdater.java:updateSchema:126) Force mode: could not find data types for fields [nh:Observation_Parameters/nh:telemetry_apid, nh:Detector/nh:detector_name, sb:Exposure/sb:exposure_description, nh:Spacecraft_State/nh:spacecraft_spin_state, nh:Mission_Elapsed_Time/nh:stop_clock_count, sb:Exposure/sb:exposure_duration, nh:Mission_Elapsed_Time/nh:start_clock_count, nh:Observation_Parameters/nh:sequence_id, sb:Timing/sb:midobservation_time_UTC_JD, nh:Detector/nh:detector_type, nh:Mission_Elapsed_Time/nh:clock_partition, nh:Mission_Parameters/nh:mission_phase_name, nh:Observation_Parameters/nh:observation_description, sb:Timing/sb:midobservation_time_UTC_YMD] - these fields will not be indexed or searchable. Product will still be ingested.
2026-06-02 10:23:30 [INFO ] (MetadataWriter.java:writeBatch:106) Wrote 1 product(s)
2026-06-02 10:23:30 [SUMMARY] (HarvestCmd.java:printSummary:283) Summary:
2026-06-02 10:23:30 [SUMMARY] (HarvestCmd.java:printSummary:286) Skipped files: 0
2026-06-02 10:23:30 [SUMMARY] (HarvestCmd.java:printSummary:287) Loaded files: 1
2026-06-02 10:23:30 [SUMMARY] (HarvestCmd.java:printSummary:293)   Product_Observational: 1
2026-06-02 10:23:30 [SUMMARY] (HarvestCmd.java:printSummary:297) Failed files: 0
2026-06-02 10:23:30 [SUMMARY] (HarvestCmd.java:printSummary:298) Package ID: ced09015-ceb8-4c02-a6f1-cb91635bceb5
```

## ♻️ Related Issues

- Fixes NASA-PDS/registry-loader#75
- Follow-on to #278 (original force-flag / LDD-missing fix)
- Sister fix: NASA-PDS/registry-loader#69

## 🤓 Reviewer Checklist

### Documentation and PR Content
- [ ] **Documentation:** README, Wiki, or inline documentation updated
- [ ] **Issue Traceability:** PR is linked to a valid GitHub Issue
- [ ] **PR Title:** Clearly identifies what is being fixed

### Security & Quality
- [ ] **SonarCloud:** No new High or Critical security findings
- [ ] **Secrets Detection:** No sensitive information exposed
- [ ] **Code Quality:** Code follows organization style guidelines

### Testing & Validation
- [ ] **Test Accuracy:** Tests are accurate and representative
- [ ] **Coverage:** Automated tests cover new logic
- [ ] **Local Verification:** Successfully built and ran changes locally

### Maintenance
- [ ] **Backward Compatibility:** Changes do not break downstream dependencies

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)