### PR TITLE
Fix null searchAfter crash and add lastSortValue() for export pagination

### DIFF
--- a/src/main/java/gov/nasa/pds/registry/common/connection/aws/SearchImpl.java
+++ b/src/main/java/gov/nasa/pds/registry/common/connection/aws/SearchImpl.java
@@ -121,12 +121,10 @@ class SearchImpl implements Search {
   }
   @Override
   public Search all(String sortField, int size, String searchAfter) {
-    /** opensearch 3.x
-    FieldValue fv = new FieldValue.Builder().stringValue(searchAfter).build();
-    this.craftsman.searchAfter(Arrays.asList(fv));
-    */
-    /** opensearch 2.x */
-    this.craftsman.searchAfter(Arrays.asList(new FieldValue.Builder().stringValue(searchAfter).build()));
+    if (searchAfter != null) {
+      this.craftsman.searchAfter(Arrays.asList(new FieldValue.Builder().stringValue(searchAfter).build()));
+    }
+    this.craftsman.size(size);
     this.craftsman.sort(new SortOptions.Builder()
         .field(new FieldSort.Builder().field(sortField).order(SortOrder.Asc).build())
         .build());


### PR DESCRIPTION
## Summary

Fixes `SearchImpl.all()` (AWS/AOSS connection) crashing with `MissingRequiredPropertyException` under opensearch-java 3.x when `searchAfter` is null on the first page of any paginated export.

`FieldValue.Builder.stringValue(null)` throws in opensearch-java 3.x. Added a null guard matching the existing behaviour of the ES (non-AWS) `RegistryRequestBuilder`. Also adds the missing `craftsman.size(size)` call that was absent from the AWS path.

## Test plan
- [ ] Run `registry-manager export-dd` against an AOSS registry — confirm no `Missing required property` crash

## Related issues
Fixes nasa-pds/registry-mgr#188

🤖 Generated with [Claude Code](https://claude.ai/claude-code)