### PR TITLE
Guard against stale LDD sentinel blocking re-load when namespace has zero indexed fields

### DIFF
--- a/src/main/java/gov/nasa/pds/registry/common/es/service/JsonLddLoader.java
+++ b/src/main/java/gov/nasa/pds/registry/common/es/service/JsonLddLoader.java
@@ -146,6 +146,10 @@ public class JsonLddLoader {
 
     try {
       String firstFieldId = createEsDataFile(lddFile, lddFileName, namespace, tempEsDataFile, lastDate);
+      if (firstFieldId == null) {
+        // createEsDataFile logged a warning; nothing to load.
+        return false;
+      }
       loader.loadFile(tempEsDataFile);
 
       // Wait until the LDD_Info sentinel is visible (search with requestCache=false).
@@ -256,11 +260,23 @@ public class JsonLddLoader {
       ClassAttrAssociationParser caaParser = new ClassAttrAssociationParser(lddFile, ccb);
       caaParser.parse();
 
+      String firstFieldId = ccb.getFirstFieldId();
+      if (firstFieldId == null) {
+        // Zero fields were written for this namespace — do not write the LDD_Info sentinel.
+        // A sentinel with no field documents would cause all future runs to skip this LDD
+        // (believing it already loaded), leaving the namespace permanently empty in -dd.
+        log.warn("LDD {} produced no field documents for namespace '{}'. "
+            + "The LDD will be re-attempted on the next run. "
+            + "If this persists, the LDD JSON may be malformed or use an unrecognised format.",
+            lddFileName, namespace);
+        return null;
+      }
+
       // Write data dictionary version and date
       writer.writeLddInfo(namespace, lddFileName, attrParser.getImVersion(),
           attrParser.getLddVersion(), attrParser.getLddDate());
 
-      return ccb.getFirstFieldId();
+      return firstFieldId;
     } finally {
       writer.close();
     }


### PR DESCRIPTION
## 🗒️ Summary

Fixes a bug where a failed or partial LDD load left a stale `LDD_Info` sentinel in the `-dd` index, permanently blocking all future load attempts for that namespace.

**Root cause:** `createEsDataFile()` always wrote the `LDD_Info` sentinel — even when `ClassAttrAssociationParser` produced zero field documents for the target namespace (e.g. because an older LDD tooling format used an unrecognised association key). On all subsequent harvest runs, `SchemaUpdater.updateLdd()` found the sentinel and returned early without re-downloading, leaving the namespace permanently empty.

**Fix:** In `createEsDataFile()`, gate the sentinel write on `firstFieldId != null`. If zero fields were written, log a warning and return `null`. `loadOnly()` checks for `null` and skips the bulk load and visibility wait entirely, so the next run will re-attempt the full load.

Confirmed against `PDS4_SB_1J00_1110.JSON`: the `-dd` index contained the `registry:LDD_Info/sb:PDS4_SB_1J00_1110.JSON` sentinel but zero individual field documents for the `sb` namespace, causing all `sb:*` field lookups to fail.

- [x] With assistance from Claude AI (~85% of changes)

## ⚙️ Test Data and/or Report

Manual verification: delete the `sb` namespace from the `-dd` index, re-run harvest against `PDS4_SB_1J00_1110.JSON` — all `sb:*` field documents now load successfully and no sentinel is written on a zero-field parse.

## ♻️ Related Issues

Fixes NASA-PDS/registry-loader#87

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
