### PR TITLE
Warn on unresolvable LDD association and correct tooling-vs-IM-version comment

### DIFF
--- a/src/main/java/gov/nasa/pds/registry/common/dd/parser/ClassAttrAssociationParser.java
+++ b/src/main/java/gov/nasa/pds/registry/common/dd/parser/ClassAttrAssociationParser.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import com.google.gson.stream.JsonToken;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 
 /**
@@ -36,6 +38,8 @@ public class ClassAttrAssociationParser extends BaseLddParser
     ////////////////////////////////////////////////////////////////////////
     
     
+    private static final Logger log = LogManager.getLogger(ClassAttrAssociationParser.class);
+
     private Callback cb;
     private int itemCount;
 
@@ -170,9 +174,11 @@ public class ClassAttrAssociationParser extends BaseLddParser
 
     private void parseAssoc(List<String> pendingAttrIds) throws Exception
     {
-        // LDD JSON format varies by IM version:
-        //   IM <= 1.24: "identifier" (string) only
-        //   IM >= 1.25: both "attributeId" (array) and "identifier" (string) are present
+        // LDD JSON format varies by LDD tooling version (not IM version — the same IM version
+        // can produce either format depending on when the LDD was generated):
+        //   Older tooling: "identifier" (string) only; may also emit a key literally named
+        //                  "null" carrying the same ID as an array (safely ignored).
+        //   Newer tooling: both "attributeId" (array) and "identifier" (string) are present.
         // Prefer "attributeId" when present; fall back to "identifier".
         // All fields must be buffered before we can act because field order is not guaranteed.
         String identifierFallback = null;
@@ -246,6 +252,16 @@ public class ClassAttrAssociationParser extends BaseLddParser
         else if(identifierFallback != null)
         {
             pendingAttrIds.add(identifierFallback);
+        }
+        else
+        {
+            // isAttribute=true but no attribute ID was found via either key.
+            // This means the LDD JSON uses an unrecognised format — fields will be silently
+            // lost. Log a warning so format changes don't go undetected.
+            log.warn("Association in class {}:{} has isAttribute=true but no attribute ID "
+                + "could be resolved (neither 'attributeId' nor 'identifier' found). "
+                + "This field will not be indexed. The LDD JSON may use an unrecognised format.",
+                classNs, className);
         }
     }
     


### PR DESCRIPTION
## 🗒️ Summary

Adds an explicit warning when `ClassAttrAssociationParser` encounters an association with `isAttribute=true` but cannot resolve an attribute ID from either the `"attributeId"` array or the `"identifier"` string fallback. Previously this case was silently dropped, making it impossible to detect when a new or changed LDD JSON format caused fields to be lost.

Also corrects an inaccurate comment: the association key format (`"identifier"` string vs `"attributeId"` array) is determined by the **LDD tooling version**, not the IM version. The same IM version can produce either format depending on when the LDD was generated. Documents that older tooling also emits a key literally named `"null"` carrying the attribute ID array (safely skipped; `"identifier"` is the correct fallback).

**Background:** Older LDD tooling versions serialised association objects with a JSON key literally named `"null"` plus a sibling `"identifier"` string. The original parser looked for `"attributeId"` (never present in those files) and silently produced zero field mappings. This was fixed in registry-common#291, but without any warning it would have been invisible. This PR adds the warning so future format variations are detected immediately.

- [x] With assistance from Claude AI (~85% of changes)

## ⚙️ Test Data and/or Report

Covered by existing `TestLddFieldResolution` parameterised tests (MRO 1M00_1400 and CART 1Q00_1970 fixtures). The new warning path is exercised when an association has `isAttribute=true` but no resolvable ID — verified by manual inspection of the log output during a harvest run against `PDS4_SB_1J00_1110.JSON`.

## ♻️ Related Issues

Refs NASA-PDS/registry-loader#88

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
