### PR TITLE
Recreate missing java.io.tmpdir when creating LDD download temp files

### DIFF
--- a/src/main/java/gov/nasa/pds/registry/common/es/service/SchemaUpdater.java
+++ b/src/main/java/gov/nasa/pds/registry/common/es/service/SchemaUpdater.java
@@ -273,6 +273,12 @@ public class SchemaUpdater {
    * UnsupportedOperationException or IOException when POSIX attributes are applied.
    */
   public static File createLddTempFile(String prefix) throws LddException {
+    String tmpDirPath = System.getProperty("java.io.tmpdir");
+    File tmpDir = new File(tmpDirPath);
+    if (!tmpDir.exists()) {
+      tmpDir.mkdirs();
+    }
+
     try {
       return Files.createTempFile("LDD-", ".JSON",
           PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-------"))).toFile();
@@ -282,7 +288,7 @@ public class SchemaUpdater {
       } catch (IOException fallbackEx) {
         fallbackEx.addSuppressed(ex);
         throw new LddException("Failed to create temp file for LDD download for namespace '"
-            + prefix + "': " + ExceptionUtils.getMessage(fallbackEx), fallbackEx);
+            + prefix + "' in directory '" + tmpDirPath + "': " + ExceptionUtils.getMessage(fallbackEx), fallbackEx);
       }
     }
   }

--- a/src/test/java/service/TestSchemaUpdaterTempFile.java
+++ b/src/test/java/service/TestSchemaUpdaterTempFile.java
@@ -21,4 +21,26 @@ public class TestSchemaUpdaterTempFile {
             tmp.delete();
         }
     }
+
+    @Test
+    void createLddTempFile_recreatesMissingTmpDir() throws Exception {
+        String originalTmpDir = System.getProperty("java.io.tmpdir");
+        File missingTmpDir = new File(System.getProperty("java.io.tmpdir"),
+            "ldd-tmp-test-" + System.nanoTime());
+        assertFalse(missingTmpDir.exists(), "Precondition: test tmp dir must not already exist");
+
+        System.setProperty("java.io.tmpdir", missingTmpDir.getAbsolutePath());
+        File tmp = null;
+        try {
+            tmp = SchemaUpdater.createLddTempFile("test");
+            assertTrue(missingTmpDir.exists(), "Missing java.io.tmpdir must be created");
+            assertTrue(tmp.exists(), "Temp file must exist");
+        } finally {
+            System.setProperty("java.io.tmpdir", originalTmpDir);
+            if (tmp != null) {
+                tmp.delete();
+            }
+            missingTmpDir.delete();
+        }
+    }
 }


### PR DESCRIPTION
## 🗒️ Summary
`SchemaUpdater.createLddTempFile()` downloads an LDD to a temp file, trying `Files.createTempFile()` with POSIX permissions first and falling back to plain `File.createTempFile()` on failure. Both calls use the JVM's default `java.io.tmpdir` with no directory override, so on a host where that directory doesn't exist, both attempts fail identically with `IOException: The system cannot find the path specified` — and every single product that needs an LDD update fails.

This was reported against Harvest 5.1.3 on a Windows host: a bundle with 7,834 products failed 100% (0 loaded) because of this one systemic temp-directory issue, even though the referenced LDD schema itself was valid and reachable.

Fix: before attempting temp file creation, ensure the resolved `java.io.tmpdir` directory exists (`mkdirs()`), and include the resolved path in the `LddException` message if creation still fails, so the failure is actionable.

### 🤖 AI Assistance Disclosure
- [ ] No AI assistance used
- [ ] AI used for light assistance (e.g., suggestions, refactoring, documentation help, minor edits)
- [ ] AI used for moderate content generation (AI generated some code or logic, but the developer authored or heavily revised the majority)
- [x] AI generated substantial portions of this code

Estimated % of code influenced by AI: 90 %

## ⚙️ Test Data and/or Report
Added `createLddTempFile_recreatesMissingTmpDir` to `TestSchemaUpdaterTempFile`, which points `java.io.tmpdir` at a directory that does not yet exist and asserts `createLddTempFile()` creates it and succeeds. Ran locally:

```
mvn test -Dtest=TestSchemaUpdaterTempFile
...
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

## ♻️ Related Issues
Refs NASA-PDS/registry-loader#142

## 🤓 Reviewer Checklist

*Reviewers: Please verify the following before approving this pull request.*

### Documentation and PR Content
- [ ] **Documentation:** README, Wiki, or inline documentation (Sphinx, Javadoc, Docstrings) have been updated to reflect these changes.
- [ ] **Issue Traceability:** The PR is linked to a valid GitHub Issue
- [ ] **PR Title:** The PR title is "user-friendly" clearly identifying what is being fixed or the new feature being added, that if you saw it in the Release Notes for a tool, you would be able to get the gist of what was done.

### Security & Quality
- [ ] **SonarCloud:** Confirmed no new High or Critical security findings.
- [ ] **Secrets Detection:** Verified that the Secrets Detection scan passed and no sensitive information (keys, tokens, PII) is exposed.
- [ ] **Code Quality:** Code follows organization style guidelines and best practices for the specific language (e.g., PEP 8, Google Java Style).

### Testing & Validation
- [ ] **Test Accuracy:** Verified that test data is accurate, representative of real-world PDS4 scenarios, and sufficient for the logic being tested.
- [ ] **Coverage:** Automated tests cover new logic and edge cases.
- [ ] **Local Verification:** (If applicable) Successfully built and ran the changes in a local or staging environment.

### Maintenance
- [ ] **Backward Compatibility:** Confirmed that these changes do not break existing downstream dependencies or API contracts (or that breaking changes are clearly documented).
